### PR TITLE
SPINE Dataframe Makers Update for Gen2 Flat CAF Variables

### DIFF
--- a/makedf/branches.py
+++ b/makedf/branches.py
@@ -384,140 +384,459 @@ stubhitbranches = [
     "rec.slc.reco.stub.planes.hits.wire",
 ]
 
-# SPINE branches
+# ===============  SPINE branches =============== #
 # - SPINE reco interaction branches
 spineint = "rec.dlp."
-spineintbranches = [
+spineint_branches = [
     spineint + b for b in [
-    #    "is_neutrino",
-    #    "nu_id",
-    #    "id",
-        "num_particles",
-    #    "num_primaries",
-        "vertex.0",
-        "vertex.1",
-        "vertex.2",
-    #    "is_cathode_crosser",
-    #    "is_time_contained",
-    #    "is_fiducial",
-    #    "is_flash_matched",
-    #    "is_truth",
-    #    "num_particles",
-    #    "num_primary_particles",
-    #    "flash_hypo_pe",
-    #    "flash_total_pe",
+        "cathode_offset",                       # Distance from the cathode [cm].
+        "depositions_sum",                      # Sum of deposited (de-ghosted) energy [MeV].
+        "flash_hypo_pe",                        # Total PE of the hypothesized flash from OpT0Finder.
+#        "flash_ids",                            # Flash IDs for the matched flashes (uses OpT0Finder, lowest score first).
+#        "flash_scores",                         # Score of the matched flashes (uses OpT0Finder, same order as flash_ids).
+#        "flash_times",                          # Time of the matched flashes (uses OpT0Finder, same order as flash_ids).
+        "flash_total_pe",                       # Total PE of the matched flash (uses OpT0Finder, same order as flash_ids).
+#        "flash_volume_ids",                     # Volume IDs of the matched flashes (uses OpT0Finder, same order as flash_ids).
+        "id",                                   # Interaction ID (dense enumeration starting from 0 within the event).
+        "is_cathode_crosser",                   # Whether the interaction is a cathode-crosser (some particle crosses the cathode).
+        "is_contained",                         # Whether the interaction is contained within some margin from the detector walls (see SPINE configuration)
+        "is_fiducial",                          # Whether the interaction is in the fiducial volume (see SPINE configuration).
+        "is_flash_matched",                     # Whether the flash is matched to the interaction (uses OpT0Finder).
+        "is_matched",                           # Whether the interaction is matched to a true interaction.
+        "is_time_contained",                    # Whether the particle is time-contained (within the "in-time" region of the drift window).
+        "is_truth",                             # Whether the interaction is a truth interaction.
+#        "match_ids",                            # Interaction IDs of the considered matches (correspond to true interaction IDs).
+#        "match_overlaps",                       # Intersection over union (IoU) of space points of the considered matches.
+#        "module_ids",                           # Module IDs (cryostat) of the interaction.
+        "num_particles",                        # The number of particles in the interaction.
+        "num_primary_particles",                # The number of primary particles in the interaction.
+        "particle_counts.0",                    # The number of particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 0.
+        "particle_counts.1",                    # The number of particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 1.
+        "particle_counts.2",                    # The number of particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 2.
+        "particle_counts.3",                    # The number of particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 3.
+        "particle_counts.4",                    # The number of particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 4.
+        "particle_counts.5",                    # The number of particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 5.
+#        "particle_ids",                         # Particle IDs in the interaction (see 'id' attribute of SRParticleDLP).
+        "primary_particle_counts.0",            # The number of primary particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 0.
+        "primary_particle_counts.1",            # The number of primary particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 1.
+        "primary_particle_counts.2",            # The number of primary particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 2.
+        "primary_particle_counts.3",            # The number of primary particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 3.
+        "primary_particle_counts.4",            # The number of primary particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 4.
+        "primary_particle_counts.5",            # The number of primary particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 5.
+#        "primary_particle_ids",                 # Primary particle IDs in the interaction (see 'id' attribute of SRParticleDLP).
+        "size",                                 # The size of the interaction (number of voxels).
+#        "topology",                             # Topology of the interaction (e.g. "0g0e1mu0pi2p") considering only primaries.
+        "vertex.0",                               # Vertex of the interaction in detector coordinates (X coordinate).
+        "vertex.1",                               # Vertex of the interaction in detector coordinates (Y coordinate).
+        "vertex.2",                               # Vertex of the interaction in detector coordinates (Z coordinate).
+#        "particles",                            # Particles in the interaction.
     ]
 ]
 
-spineintflashbranches = [
-    spineint + b for b in [
-        "flash_scores",
-        "flash_times"
-    ]
+spineint_flashids_branches = [
+    spineint + "flash_ids"                      # Flash IDs for the matched flashes (uses OpT0Finder, lowest score first).
+]
+spineint_flashscores_branches = [
+    spineint + "flash_scores"                   # Score of the matched flashes (uses OpT0Finder, same order as flash_ids).  
+]
+spineint_flashtimes_branches = [
+    spineint + "flash_times"                    # Time of the matched flashes (uses OpT0Finder, same order as flash_ids).
+]
+spineint_flashvolumeids_branches = [
+    spineint + "flash_volume_ids"               # Volume IDs of the matched flashes (uses OpT0Finder, same order as flash_ids).
 ]
 
-spineintmatchedbranches = [
-    spineint + "match_ids",
+spineint_matched_branches = [
+    spineint + "match_ids"                      # Interaction IDs of the considered matches (correspond to true interaction IDs).
+]
+spineint_matchovrlp_branches = [
+    spineint + "match_overlaps"                 # Intersection over union (IoU) of space points of the considered matches.
 ]
 
-spineintmatchovrlpbranches = [
-    spineint + "match_overlaps",
+spineint_moduleids_branches = [
+    spineint + "module_ids"                     # Module IDs (cryostat) of the interaction.
+]
+
+spineint_particleids_branches = [
+    spineint + "particle_ids"                   # Particle IDs in the interaction (see 'id' attribute of SRParticleDLP).
+]
+spineint_primaryparticleids_branches = [
+    spineint + "primary_particle_ids"           # Primary particle IDs in the interaction (see 'id' attribute of SRParticleDLP).
 ]
 
 # - SPINE true interaction branches
 spinetint = "rec.dlp_true."
 
-spinetintbranches = [
+spinetint_branches = [
     spinetint + b for b in [
-        "id",
-        "nu_id",
-        "current_type",
-        "energy_init",
-        "energy_transfer",
-        "num_particles",
-        "num_primary_particles",
-        "inelasticity",
-        "interaction_mode",
-        "interaction_type",
-        "is_cathode_crosser",
-        "is_time_contained",
-        "is_contained",
-        "is_fiducial",
-        "lepton_p",
-        "lepton_pdg_code",
-        "mct_index"
+        "bjorken_x",                            # Bjorken x of the neutrino interaction.
+        "cathode_offset",                       # Distance from the cathode [cm].
+#        "creation_process",                     # Creation process associated with the neutrino (see MCParticle).
+        "current_type",                         # Current type of the neutrino (see MCNeutrino; 0=CC, 1=NC).
+        "depositions_adapt_q_sum",              # Total tagged (reco non-ghost) charge deposited [ADC].
+        "depositions_adapt_sum",                # Total tagged (reco non-ghost) energy deposited [MeV].
+        "depositions_g4_sum",                   # Total energy deposited energy at the G4 level [MeV].
+        "depositions_q_sum",                    # Total tagged (true non-ghost) charge deposited [ADC].
+        "depositions_sum",                      # Total tagged (true non-ghost) energy deposited [MeV].
+        "distance_travel",                      # Distance traveled by the neutrino from production to the interaction.
+        "energy_init",                          # Initial energy of the neutrino.
+        "energy_transfer",                      # Energy transfer (Q0) of the neutrino interaction.
+        "flash_hypo_pe",                        # Total PE of the hypothesized flash.
+#        "flash_ids",                            # Flash IDs for the matched flashes (uses OpT0Finder, lowest score first).
+#        "flash_scores",                         # Flash score for the matched flashes (uses OpT0Finder, same order as flash_ids).
+#        "flash_times",                          # Time of the matched flashes (uses OpT0Finder, same order as flash_ids).
+        "flash_total_pe",                       # Total PE of the matched flash.
+#        "flash_volume_ids",                     # Volume IDs of the matched flashes (uses OpT0Finder, same order as flash_ids).
+        "hadronic_invariant_mass",              # Hadronic invariant mass of the neutrino.
+        "id",                                   # Interaction ID (dense enumeration starting from 0 within the event).
+        "inelasticity",                         # Inelasticity of the neutrino interaction.
+        "interaction_mode",                     # Interaction mode of the neutrino (see MCNeutrino).
+        "interaction_type",                     # Interaction type of the neutrino (see MCNeutrino).
+        "is_cathode_crosser",                   # Whether the interaction is a cathode-crosser (some particle crosses the cathode).
+        "is_contained",                         # Whether the interaction is contained within some margin from the detector walls.
+        "is_fiducial",                          # Whether the interaction is in the fiducial volume (see SPINE configuration).
+        "is_flash_matched",                     # Whether the flash is matched to the interaction.
+        "is_matched",                           # Whether the interaction is matched to a true interaction.
+        "is_time_contained",                    # Whether the particle is time-contained (within the "in-time" region of the drift window).
+        "is_truth",                             # Whether the interaction is a truth interaction.
+        "lepton_p",                             # Momentum of the lepton in the interaction.
+        "lepton_pdg_code",                      # PDG code of the lepton in the interaction.
+        "lepton_track_id",                      # Track ID of the lepton in the neutrino interaction.
+#        "match_ids",                            # Interaction IDs of the considered matches (correspond to reco interaction IDs).
+#        "match_overlaps",                       # Intersection over union (IoU) of space points of the considered matches.
+        "mct_index",                            # Index of the neutrino in the original MCTruth array.
+#        "module_ids",                           # Module IDs (cryostat) of the interaction.
+        "momentum.0",                           # Momentum (vector) of the neutrino (X coordinate).
+        "momentum.1",                           # Momentum (vector) of the neutrino (Y coordinate).
+        "momentum.2",                           # Momentum (vector) of the neutrino (Z coordinate).
+        "momentum_transfer",                    # Momentum transfer (Q^2) of the neutrino interaction.
+        "momentum_transfer_mag",                # Momentum transfer (Q3) of the neutrino interaction.
+        "nu_id",                                # Neutrino ID (-1 = not a neutrino, 0 = first neutrino, 1 = second neutrino, etc.).
+        "nucleon",                              # Hit nucleon in the neutrino interaction (see MCNeutrino).
+        "num_particles",                        # Number of particles in the interaction.
+        "num_primary_particles",                # Number of primary particles in the interaction.
+        "orig_id",                              # Original ID of the interaction (from Geant4).
+        "particle_counts.0",                    # Number of particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 0.
+        "particle_counts.1",                    # Number of particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 1.
+        "particle_counts.2",                    # Number of particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 2.
+        "particle_counts.3",                    # Number of particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 3.
+        "particle_counts.4",                    # Number of particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 4.
+        "particle_counts.5",                    # Number of particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 5.
+#        "particle_ids",                         # Particle IDs in the interaction (see 'id' attribute of SRParticleTruthDLP).
+        "pdg_code",                             # PDG code of the neutrino.
+        "position.0",                           # Position of the neutrino interaction (X coordinate).
+        "position.1",                           # Position of the neutrino interaction (Y coordinate).
+        "position.2",                           # Position of the neutrino interaction (Z coordinate).
+        "primary_particle_counts.0",            # Number of primary particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 0.
+        "primary_particle_counts.1",            # Number of primary particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 1.
+        "primary_particle_counts.2",            # Number of primary particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 2.
+        "primary_particle_counts.3",            # Number of primary particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 3.
+        "primary_particle_counts.4",            # Number of primary particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 4.
+        "primary_particle_counts.5",            # Number of primary particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 5.
+#        "primary_particle_ids",                 # Primary particle IDs in the interaction (see 'id' attribute of SRParticleTruthDLP).
+        "quark",                                # Hit quark in the neutrino interaction (see MCNeutrino).
+        "reco_vertex.0",                        # Vertex of the interaction in detector coordinates (reco) (X coordinate).
+        "reco_vertex.1",                        # Vertex of the interaction in detector coordinates (reco) (Y coordinate).
+        "reco_vertex.2",                        # Vertex of the interaction in detector coordinates (reco) (Z coordinate).
+        "size",                                 # Number of true non-ghost true-tagged space points.
+        "size_adapt",                           # Number of reco non-ghost true-tagged space points.
+        "size_g4",                              # Number of (rasterized) g4 energy depositions (no detector effects).
+        "target",                               # Target in the neutrino interaction.
+        "theta",                                # Angle between the neutrino and the outgoing lepton [radians].
+#        "topology",                             # Topology of the interaction (e.g. "0g0e1mu0pi2p") considering only primaries.
+        "track_id",                             # Track ID of the neutrino interaction.
+        "vertex.0",                             # Vertex of the interaction in detector coordinates (truth) (X coordinate).
+        "vertex.1",                             # Vertex of the interaction in detector coordinates (truth) (Y coordinate).
+        "vertex.2",                             # Vertex of the interaction in detector coordinates (truth) (Z coordinate).
+#        "particles",                            # Particles in the interaction.
     ]
 ]
+
+spinetint_flashids_branches = [
+    spinetint + "flash_ids"                      # Flash IDs for the matched flashes (uses OpT0Finder, lowest score first).
+]
+spinetint_flashscores_branches = [
+    spinetint + "flash_scores"                   # Flash score for the matched flashes (uses OpT0Finder, same order as flash_ids).  
+]
+spinetint_flashtimes_branches = [
+    spinetint + "flash_times"                    # Time of the matched flashes (uses OpT0Finder, same order as flash_ids).
+]
+spinetint_flashvolumeids_branches = [
+    spinetint + "flash_volume_ids"               # Volume IDs of the matched flashes (uses OpT0Finder, same order as flash_ids).
+]
+spinetint_matched_branches = [
+    spinetint + "match_ids"                      # Interaction IDs of the considered matches (correspond to reco interaction IDs).
+]
+spinetint_matchovrlp_branches = [
+    spinetint + "match_overlaps"                 # Intersection over union (IoU) of space points of the considered matches.
+]
+spinetint_moduleids_branches = [
+    spinetint + "module_ids"                     # Module IDs (cryostat) of the interaction.
+]
+spinetint_particleids_branches = [
+    spinetint + "particle_ids"                   # Particle IDs in the interaction (see 'id' attribute of SRParticleTruthDLP).
+]
+spinetint_primaryparticleids_branches = [
+    spinetint + "primary_particle_ids"           # Primary particle IDs in the interaction (see 'id' attribute of SRParticleTruthDLP).
+]
+
 
 # - SPINE reco particle branches
 spinepart = "rec.dlp.particles."
 
-spinepartbranches = [
+spinepart_branches = [
     spinepart + b for b in [
-        "calo_ke",
-        "cathode_offset",
-        # "chi2_per_pid.0",
-        # "chi2_per_pid.1",
-        # "chi2_per_pid.2",
-        # "chi2_per_pid.3",
-        # "chi2_per_pid.4",
-        # "chi2_per_pid.5",
-        # "chi2_pid",
-        "end_point.0",
-        "end_point.1",
-        "end_point.2",
-        "end_dir.0",
-        "end_dir.1",
-        "end_dir.2",
-        "interaction_id",
-        "id",
-        "is_contained",
-        "is_primary",
-        "is_valid",
-        "length",
-        "csda_ke",
-        "csda_ke_per_pid.0",
-        "csda_ke_per_pid.1",
-        "csda_ke_per_pid.2",
-        "csda_ke_per_pid.3",
-        "csda_ke_per_pid.4",
-        "csda_ke_per_pid.5",
-        "ke",
-        "p",
-        "momentum.0",
-        "momentum.1",
-        "momentum.2",
-        "mcs_ke",
-        "mcs_ke_per_pid.0",
-        "mcs_ke_per_pid.1",
-        "mcs_ke_per_pid.2",
-        "mcs_ke_per_pid.3",
-        "mcs_ke_per_pid.4",
-        "mcs_ke_per_pid.5",
-        "pid",
-        "pid_scores.0",
-        "pid_scores.1",
-        "pid_scores.2",
-        "pid_scores.3",
-        "pid_scores.4",
-        "start_point.0",
-        "start_point.1",
-        "start_point.2",
-        "start_dir.0",
-        "start_dir.1",
-        "start_dir.2",
-        "start_dedx"
+        "axial_spread",                         # Axial spread of the particle.
+        "calo_ke",                              # Calorimetric kinetic energy.
+        "cathode_offset",                       # Distance from the cathode [cm].
+        "chi2_per_pid.0",                       # Chi2 score for PID hypothesis 0.
+        "chi2_per_pid.1",                       # Chi2 score for PID hypothesis 1.
+        "chi2_per_pid.2",                       # Chi2 score for PID hypothesis 2.
+        "chi2_per_pid.3",                       # Chi2 score for PID hypothesis 3.
+        "chi2_per_pid.4",                       # Chi2 score for PID hypothesis 4.
+        "chi2_per_pid.5",                       # Chi2 score for PID hypothesis 5.
+        "chi2_pid",                             # PID from the chi2-based PID.
+        "csda_ke",                              # Continuous-slowing-down-approximation kinetic energy.
+        "csda_ke_per_pid.0",                    # CSDA kinetic energy for PID 0.
+        "csda_ke_per_pid.1",                    # CSDA kinetic energy for PID 1.
+        "csda_ke_per_pid.2",                    # CSDA kinetic energy for PID 2.
+        "csda_ke_per_pid.3",                    # CSDA kinetic energy for PID 3.
+        "csda_ke_per_pid.4",                    # CSDA kinetic energy for PID 4.
+        "csda_ke_per_pid.5",                    # CSDA kinetic energy for PID 5.
+        "depositions_sum",                      # Sum of deposited (de-ghosted) energy [MeV].
+        "directional_spread",                   # Directional spread of the particle.
+        "end_dir.0",                            # Unit direction vector calculated at the particle end point (X coordinate).
+        "end_dir.1",                            # Unit direction vector calculated at the particle end point (Y coordinate).
+        "end_dir.2",                            # Unit direction vector calculated at the particle end point (Z coordinate).
+        "end_point.0",                          # End point (vector) of the particle (X coordinate).
+        "end_point.1",                          # End point (vector) of the particle (Y coordinate).
+        "end_point.2",                          # End point (vector) of the particle (Z coordinate).
+#        "fragment_ids",                        # Fragment IDs comprising the particle.
+        "id",                                   # Particle ID (dense enumeration starting from 0 within the event).
+        "interaction_id",                       # Parent interaction ID.
+        "is_cathode_crosser",                   # Whether the particle is a cathode-crosser.
+        "is_contained",                         # Whether the particle is contained within some margin from the detector walls (see SPINE configuration).
+        "is_matched",                           # Whether the particle is matched.
+        "is_primary",                           # Whether the particle is a primary particle.
+        "is_time_contained",                    # Whether the particle is time-contained (within the "in-time" region of the drift window).
+        "is_truth",                             # Whether the particle is a truth particle.
+        "is_valid",                             # Whether the particle passes thresholds and counts towards the topology.
+        "ke",                                   # Kinetic energy from best energy estimator (CSDA, calorimetric, or MCS).
+        "length",                               # Length of the particle.
+        "mass",                                 # Mass of the particle (according to assigned PID).
+#        "match_ids",                           # Particle IDs of the considered matches (correspond to true particle IDs).
+#        "match_overlaps",                      # Intersection over union (IoU) of space points of the considered matches.
+        "mcs_ke",                               # Multiple Coulomb scattering kinetic energy.
+        "mcs_ke_per_pid.0",                     # MCS kinetic energy for PID 0.
+        "mcs_ke_per_pid.1",                     # MCS kinetic energy for PID 1.
+        "mcs_ke_per_pid.2",                     # MCS kinetic energy for PID 2.
+        "mcs_ke_per_pid.3",                     # MCS kinetic energy for PID 3.
+        "mcs_ke_per_pid.4",                     # MCS kinetic energy for PID 4.
+        "mcs_ke_per_pid.5",                     # MCS kinetic energy for PID 5.
+#        "module_ids",                          # Module IDs (cryostat) of the particle.
+        "momentum.0",                           # Momentum (vector) of the particle (X coordinate).
+        "momentum.1",                           # Momentum (vector) of the particle (Y coordinate).
+        "momentum.2",                           # Momentum (vector) of the particle (Z coordinate).
+        "num_fragments",                        # Number of fragments comprising the particle.
+        "p",                                    # Momentum magnitude.
+        "pdg_code",                             # PDG code of the particle.
+        "pid",                                  # Particle ID (see Pid_t enumeration).
+        "pid_scores.0",                         # PID 0 softmax scores.
+        "pid_scores.1",                         # PID 1 softmax scores.
+        "pid_scores.2",                         # PID 2 softmax scores.
+        "pid_scores.3",                         # PID 3 softmax scores.
+        "pid_scores.4",                         # PID 4 softmax scores.
+        "pid_scores.5",                         # PID 5 softmax scores.
+#        "ppn_ids",                             # PPN IDs of the particle.
+        "primary_scores.0",                     # Primary score for PID 0.
+        "primary_scores.1",                     # Primary score for PID 1.
+        "shape",                                # Semantic type of the particle (see Shape_t enumeration).
+        "size",                                 # The size of the particle (number of voxels).
+        "start_dedx",                           # dE/dx at the start of the particle.
+        "start_dir.0",                          # Unit direction vector calculated at the particle start point (X coordinate).
+        "start_dir.1",                          # Unit direction vector calculated at the particle start point (Y coordinate).
+        "start_dir.2",                          # Unit direction vector calculated at the particle start point (Z coordinate).
+        "start_point.0",                        # Start point (vector) of the particle (X coordinate).
+        "start_point.1",                        # Start point (vector) of the particle (Y coordinate).
+        "start_point.2",                        # Start point (vector) of the particle (Z coordinate).
+        "start_straightness",                   # Straightness at the start of the particle.
+        "vertex_distance"                       # Distance from the vertex.
     ]
 ]
 
-spinepartmatchedbranches = [
-    spinepart + "match_ids",
+spinepart_fragmentids_branches = [
+    spinepart + "fragment_ids"                  # Fragment IDs comprising the particle.
 ]
 
-spinepartmatchovrlpbranches = [
-    spinepart + "match_overlaps"
+spinepart_matched_branches = [
+    spinepart + "match_ids"                     # Particle IDs of the considered matches (correspond to true particle IDs).
+]
+
+spinepart_matchovrlp_branches = [
+    spinepart + "match_overlaps"                # Intersection over union (IoU) of space points of the considered matches.
+]
+
+spinepart_moduleids_branches = [
+    spinepart + "module_ids"                    # Module IDs (cryostat) of the particle.
+]
+
+spinepart_ppnids_branches = [
+    spinepart + "ppn_ids"                       # PPN IDs of the particle.
 ]
 
 # - SPINE true particle branches
 spinetpart = "rec.dlp_true.particles."
-spinetpartbranches = [spinetpart + "track_id"] + [k.replace(spinepart, spinetpart) for k in spinepartbranches if "pid_scores" not in k and "start_dedx" not in k]
+
+spinetpart_branches = [
+    spinetpart + b for b in [
+#        "ancestor_creation_process",           # Geant4 creation process of the ancestor particle.
+        "ancestor_pdg_code",                    # PDG code of the ancestor particle.
+        "ancestor_position.0",                  # Position of the ancestor particle (X coordinate).
+        "ancestor_position.1",                  # Position of the ancestor particle (Y coordinate).
+        "ancestor_position.2",                  # Position of the ancestor particle (Z coordinate).
+        "ancestor_t",                           # Time of the ancestor particle.
+        "ancestor_track_id",                    # Track ID of the ancestor particle.
+        "calo_ke",                              # Calorimetric kinetic energy.
+        "cathode_offset",                       # Distance from the cathode [cm].
+#        "children_counts",                     # Number of children of the particle.
+#        "children_id",                         # List of particle ID of children particles.
+#        "creation_process",                    # Geant4 creation process associated with the particle (see MCParticle).
+        "csda_ke",                              # Continuous-slowing-down-approximation kinetic energy.
+        "csda_ke_per_pid.0",                    # CSDA kinetic energy per PID (PID 0).
+        "csda_ke_per_pid.1",                    # CSDA kinetic energy per PID (PID 1).
+        "csda_ke_per_pid.2",                    # CSDA kinetic energy per PID (PID 2).
+        "csda_ke_per_pid.3",                    # CSDA kinetic energy per PID (PID 3).
+        "csda_ke_per_pid.4",                    # CSDA kinetic energy per PID (PID 4).
+        "csda_ke_per_pid.5",                    # CSDA kinetic energy per PID (PID 5).
+        "depositions_adapt_q_sum",              # Total tagged (reco non-ghost) charge deposited [ADC].
+        "depositions_adapt_sum",                # Total tagged (reco non-ghost) energy deposited [MeV].
+        "depositions_g4_sum",                   # Total energy deposited energy at the G4 level [MeV].
+        "depositions_q_sum",                    # Total tagged (true non-ghost) charge deposited [ADC].
+        "depositions_sum",                      # Total tagged (true non-ghost) energy deposited [MeV].
+        "distance_travel",                      # Distance traveled by the neutrino from production to the interaction.
+        "end_dir.0",                            # Unit direction vector at the particle end point (X coordinate).
+        "end_dir.1",                            # Unit direction vector at the particle end point (Y coordinate).
+        "end_dir.2",                            # Unit direction vector at the particle end point (Z coordinate).
+        "end_momentum.0",                       # Momentum vector at the particle end (X coordinate).
+        "end_momentum.1",                       # Momentum vector at the particle end (Y coordinate).
+        "end_momentum.2",                       # Momentum vector at the particle end (Z coordinate).
+        "end_p",                                # Momentum magnitude of the particle at the end.
+        "end_point.0",                          # End point vector of the particle (X coordinate).
+        "end_point.1",                          # End point vector of the particle (Y coordinate).
+        "end_point.2",                          # End point vector of the particle (Z coordinate).
+        "end_position.0",                       # End position vector of the particle (X coordinate).
+        "end_position.1",                       # End position vector of the particle (Y coordinate).
+        "end_position.2",                       # End position vector of the particle (Z coordinate).
+        "end_t",                                # Time of the particle at the end.
+        "energy_deposit",                       # Energy deposited by the particle.
+        "energy_init",                          # Initial energy of the particle.
+        "first_step.0",                         # X coordinate of the first step of the particle.
+        "first_step.1",                         # Y coordinate of the first step oftheparticle.
+        "first_step.2",                         # Z coordinate of the first stepoftheparticle.
+#        "fragment_ids",                        # Fragment IDs comprising the particle.
+        "group_id",                             # Group ID of the particle.
+        "group_primary",                        # Whether the particle is a primary within its group.
+        "id",                                   # Particle ID (dense enumeration starting from 0 within the event).
+        "interaction_id",                       # Parent interaction ID.
+        "interaction_primary",                  # Whether the particle is a primary within its interaction (equivalent to is_primary).
+        "is_cathode_crosser",                   # Whether the particle is a cathode-crosser.
+        "is_contained",                         # Whether the particle is contained within some margin from the detector walls (see SPINE configuration).
+        "is_matched",                           # Whether the particle is matched.
+        "is_primary",                           # Whether the particle is a primary particle.
+        "is_time_contained",                    # Whether the particle is time-contained (within the "in-time" region of the drift window).
+        "is_truth",                             # Whether the particle is a truth particle.
+        "is_valid",                             # Whether the particle passes thresholds and counts towards topology.
+        "ke",                                   # Kinetic energy from best energy estimator (CSDA, calorimetric, or MCS).
+        "last_step.0",                          # X coordinate of the last step of the particle.
+        "last_step.1",                          # Y coordinate of the coordinates of the last step of the particle.
+        "last_step.2",                          # Z coordinate of the coordinates of the last step of the particle.
+        "length",                               # Length of the particle.
+        "mass",                                 # Mass of the particle.
+#        "match_ids",                           # Particle IDs of the considered matches (correspond to reco particle IDs).
+#        "match_overlaps",                      # Intersection over union (IoU) of space points of the considered matches.
+        "mcs_ke",                               # Multiple Coulomb scattering kinetic energy.
+        "mcs_ke_per_pid.0",                     # MCS kinetic energy per PID.
+        "mcs_ke_per_pid.1",                     # MCS kinetic energy per PID.
+        "mcs_ke_per_pid.2",                     # MCS kinetic energy per PID.
+        "mcs_ke_per_pid.3",                     # MCS kinetic energy per PID.
+        "mcs_ke_per_pid.4",                     # MCS kinetic energy per PID.
+        "mcs_ke_per_pid.5",                     # MCS kinetic energy per PID.
+        "mcst_index",                           # MCST index.
+        "mct_index",                            # Index of the particle in the original MCTruth array.
+#        "module_ids",                          # Module IDs (cryostat) of the particle.
+        "momentum.0",                           # Mmomentum (vector) of the particle (X coordinate).
+        "momentum.1",                           # Momentum (vector) of the particle (Y coordinate).
+        "momentum.2",                           # Momentum (vector) of the particle (Z coordinate).
+        "nu_id",                                # Neutrino ID (-1 = not a neutrino, 0 = first neutrino, 1 = second neutrino, etc.).
+        "num_fragments",                        # Number of particle fragments.
+        "num_voxels",                           # Number of voxels comprising the particle.
+#        "orig_children_id",                    # Original ID of the children particles.
+        "orig_group_id",                        # Original group ID of the particle.
+        "orig_id",                              # Original ID of the particle.
+        "orig_interaction_id",                  # Interaction ID as it was stored in the parent LArCV file under the interaction_id attribute.
+        "orig_parent_id",                       # Parent ID as it was stored in the parent LArCV file under the parent_id attribute.
+        "p",                                    # Momentum magnitude.
+#        "parent_creation_process",             # Geant4 creation process of the parent particle.
+        "parent_id",                            # Parent particle ID.
+        "parent_pdg_code",                      # PDG code of the parent particle.
+        "parent_position.0",                    # Position of the parent particle (X coordinate).
+        "parent_position.1",                    # Position of the parent particle (Y coordinate).
+        "parent_position.2",                    # Position of the parent particle (Z coordinate).
+        "parent_t",                             # Time of the parent particle.
+        "parent_track_id",                      # Track ID of the parent particle.
+        "pdg_code",                             # PDG code of the particle.
+        "pid",                                  # Particle ID (see Pid enumeration).
+        "position.0",                           # Position of the particle (X coordinate).
+        "position.1",                           # Position of the particle (Y coordinate).
+        "position.2",                           # Position of the particle (Z coordinate).
+        "reco_end_dir.0",                       # Direction vector at the reconstructed end point of the particle (X coordinate).
+        "reco_end_dir.1",                       # Direction vector at the reconstructed end point of the particle (Y coordinate).
+        "reco_end_dir.2",                       # Direction vector at the reconstructed end point of the particle (Z coordinate).
+        "reco_ke",                              # Kinetic energy estimator using reconstructed information.
+        "reco_length",                          # Reconstructed length of the particle.
+        "reco_momentum.0",                      # Reconstructed momentum (vector) of the particle.
+        "reco_momentum.1",                      # Reconstructed momentum (vector) of the particle.
+        "reco_momentum.2",                      # Reconstructed momentum (vector) of the particle.
+        "reco_start_dir.0",                     # Direction vector at the reconstructed start point of the particle (X coordinate).
+        "reco_start_dir.1",                     # Direction vector at the reconstructed start point of the particle (Y coordinate).
+        "reco_start_dir.2",                     # Direction vector at the reconstructed start point of the particle (Z coordinate).
+        "shape",                                # Semantic type of the particle (see SemanticType enumeration).
+        "size",                                 # Size of the particle (number of voxels).
+        "size_adapt",                           # Size of the particle using adaptive thresholds (number of voxels).
+        "size_g4",                              # Size of the particle at the G4 level (number of voxels).
+        "start_dir.0",                          # Unit direction vector at the particle start point (X coordinate).
+        "start_dir.1",                          # Unit direction vector at the particle start point (Y coordinate).
+        "start_dir.2",                          # Unit direction vector at the particle start point (Z coordinate).
+        "start_point.0",                        # Position of the start point (vector) of the particle (X coordinate).
+        "start_point.1",                        # Position of the start point (vector) of the particle (Y coordinate).
+        "start_point.2",                        # Position of the start point (vector) of the particle (Z coordinate).
+        "t",                                    # Time of the particle.
+        "track_id"                              # Track ID of the particle.
+    ]   
+]   
+
+
+spinetpart_childrenid_branches = [
+    spinetpart + "children_id"              # List of particle ID of children particles.
+]
+
+spinetpart_fragmentids_branches = [
+    spinetpart + "fragment_ids"             # Fragment IDs comprising the particle.
+]
+
+spinetpart_matched_branches = [
+    spinetpart + "match_ids"                # Particle IDs of the considered matches (correspond to reco particle IDs).
+]
+
+spinetpart_matchovrlp_branches = [
+    spinetpart + "match_overlaps"           # Intersection over union (IoU) of space points of the considered matches.
+]
+
+spinetpart_moduleids_branches = [
+    spinetpart + "module_ids"               # Module IDs (cryostat) of the particle.
+]
+
+spinetpart_originchildrenid_branches = [
+    spinetpart + "orig_children_id"         # Original ID of the children particles.
+]
+

--- a/makedf/branches.py
+++ b/makedf/branches.py
@@ -387,21 +387,21 @@ stubhitbranches = [
 eslc = "rec.dlp."
 
 eslcbranches = [
-    eslc + "is_neutrino",
-    eslc + "nu_id",
+#    eslc + "is_neutrino",
+#    eslc + "nu_id",
     eslc + "num_particles",
-    eslc + "num_primaries",
+#    eslc + "num_primaries",
     eslc + "vertex.0",
     eslc + "vertex.1",
     eslc + "vertex.2",
 ]
 
 eslcmatchedbranches = [
-    eslc + "match",
+    eslc + "match_ids", # "match"
 ]
 
 eslcmatchovrlpbranches = [
-    eslc + "match_overlap",
+    eslc + "match_overlaps", # "match_overlap"
 ]
 
 inter = "rec.dlp."

--- a/makedf/branches.py
+++ b/makedf/branches.py
@@ -392,11 +392,7 @@ spineint_branches = [
         "cathode_offset",                       # Distance from the cathode [cm].
         "depositions_sum",                      # Sum of deposited (de-ghosted) energy [MeV].
         "flash_hypo_pe",                        # Total PE of the hypothesized flash from OpT0Finder.
-#        "flash_ids",                            # Flash IDs for the matched flashes (uses OpT0Finder, lowest score first).
-#        "flash_scores",                         # Score of the matched flashes (uses OpT0Finder, same order as flash_ids).
-#        "flash_times",                          # Time of the matched flashes (uses OpT0Finder, same order as flash_ids).
         "flash_total_pe",                       # Total PE of the matched flash (uses OpT0Finder, same order as flash_ids).
-#        "flash_volume_ids",                     # Volume IDs of the matched flashes (uses OpT0Finder, same order as flash_ids).
         "id",                                   # Interaction ID (dense enumeration starting from 0 within the event).
         "is_cathode_crosser",                   # Whether the interaction is a cathode-crosser (some particle crosses the cathode).
         "is_contained",                         # Whether the interaction is contained within some margin from the detector walls (see SPINE configuration)
@@ -405,9 +401,6 @@ spineint_branches = [
         "is_matched",                           # Whether the interaction is matched to a true interaction.
         "is_time_contained",                    # Whether the particle is time-contained (within the "in-time" region of the drift window).
         "is_truth",                             # Whether the interaction is a truth interaction.
-#        "match_ids",                            # Interaction IDs of the considered matches (correspond to true interaction IDs).
-#        "match_overlaps",                       # Intersection over union (IoU) of space points of the considered matches.
-#        "module_ids",                           # Module IDs (cryostat) of the interaction.
         "num_particles",                        # The number of particles in the interaction.
         "num_primary_particles",                # The number of primary particles in the interaction.
         "particle_counts.0",                    # The number of particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 0.
@@ -416,19 +409,17 @@ spineint_branches = [
         "particle_counts.3",                    # The number of particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 3.
         "particle_counts.4",                    # The number of particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 4.
         "particle_counts.5",                    # The number of particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 5.
-#        "particle_ids",                         # Particle IDs in the interaction (see 'id' attribute of SRParticleDLP).
         "primary_particle_counts.0",            # The number of primary particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 0.
         "primary_particle_counts.1",            # The number of primary particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 1.
         "primary_particle_counts.2",            # The number of primary particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 2.
         "primary_particle_counts.3",            # The number of primary particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 3.
         "primary_particle_counts.4",            # The number of primary particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 4.
         "primary_particle_counts.5",            # The number of primary particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 5.
-#        "primary_particle_ids",                 # Primary particle IDs in the interaction (see 'id' attribute of SRParticleDLP).
         "size",                                 # The size of the interaction (number of voxels).
 #        "topology",                             # Topology of the interaction (e.g. "0g0e1mu0pi2p") considering only primaries.
-        "vertex.0",                               # Vertex of the interaction in detector coordinates (X coordinate).
-        "vertex.1",                               # Vertex of the interaction in detector coordinates (Y coordinate).
-        "vertex.2",                               # Vertex of the interaction in detector coordinates (Z coordinate).
+        "vertex.0",                             # Vertex of the interaction in detector coordinates (X coordinate).
+        "vertex.1",                             # Vertex of the interaction in detector coordinates (Y coordinate).
+        "vertex.2",                             # Vertex of the interaction in detector coordinates (Z coordinate).
 #        "particles",                            # Particles in the interaction.
     ]
 ]
@@ -436,12 +427,15 @@ spineint_branches = [
 spineint_flashids_branches = [
     spineint + "flash_ids"                      # Flash IDs for the matched flashes (uses OpT0Finder, lowest score first).
 ]
+
 spineint_flashscores_branches = [
     spineint + "flash_scores"                   # Score of the matched flashes (uses OpT0Finder, same order as flash_ids).  
 ]
+
 spineint_flashtimes_branches = [
     spineint + "flash_times"                    # Time of the matched flashes (uses OpT0Finder, same order as flash_ids).
 ]
+
 spineint_flashvolumeids_branches = [
     spineint + "flash_volume_ids"               # Volume IDs of the matched flashes (uses OpT0Finder, same order as flash_ids).
 ]
@@ -449,6 +443,7 @@ spineint_flashvolumeids_branches = [
 spineint_matched_branches = [
     spineint + "match_ids"                      # Interaction IDs of the considered matches (correspond to true interaction IDs).
 ]
+
 spineint_matchovrlp_branches = [
     spineint + "match_overlaps"                 # Intersection over union (IoU) of space points of the considered matches.
 ]
@@ -460,6 +455,7 @@ spineint_moduleids_branches = [
 spineint_particleids_branches = [
     spineint + "particle_ids"                   # Particle IDs in the interaction (see 'id' attribute of SRParticleDLP).
 ]
+
 spineint_primaryparticleids_branches = [
     spineint + "primary_particle_ids"           # Primary particle IDs in the interaction (see 'id' attribute of SRParticleDLP).
 ]
@@ -482,11 +478,7 @@ spinetint_branches = [
         "energy_init",                          # Initial energy of the neutrino.
         "energy_transfer",                      # Energy transfer (Q0) of the neutrino interaction.
         "flash_hypo_pe",                        # Total PE of the hypothesized flash.
-#        "flash_ids",                            # Flash IDs for the matched flashes (uses OpT0Finder, lowest score first).
-#        "flash_scores",                         # Flash score for the matched flashes (uses OpT0Finder, same order as flash_ids).
-#        "flash_times",                          # Time of the matched flashes (uses OpT0Finder, same order as flash_ids).
         "flash_total_pe",                       # Total PE of the matched flash.
-#        "flash_volume_ids",                     # Volume IDs of the matched flashes (uses OpT0Finder, same order as flash_ids).
         "hadronic_invariant_mass",              # Hadronic invariant mass of the neutrino.
         "id",                                   # Interaction ID (dense enumeration starting from 0 within the event).
         "inelasticity",                         # Inelasticity of the neutrino interaction.
@@ -502,10 +494,7 @@ spinetint_branches = [
         "lepton_p",                             # Momentum of the lepton in the interaction.
         "lepton_pdg_code",                      # PDG code of the lepton in the interaction.
         "lepton_track_id",                      # Track ID of the lepton in the neutrino interaction.
-#        "match_ids",                            # Interaction IDs of the considered matches (correspond to reco interaction IDs).
-#        "match_overlaps",                       # Intersection over union (IoU) of space points of the considered matches.
         "mct_index",                            # Index of the neutrino in the original MCTruth array.
-#        "module_ids",                           # Module IDs (cryostat) of the interaction.
         "momentum.0",                           # Momentum (vector) of the neutrino (X coordinate).
         "momentum.1",                           # Momentum (vector) of the neutrino (Y coordinate).
         "momentum.2",                           # Momentum (vector) of the neutrino (Z coordinate).
@@ -522,7 +511,6 @@ spinetint_branches = [
         "particle_counts.3",                    # Number of particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 3.
         "particle_counts.4",                    # Number of particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 4.
         "particle_counts.5",                    # Number of particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 5.
-#        "particle_ids",                         # Particle IDs in the interaction (see 'id' attribute of SRParticleTruthDLP).
         "pdg_code",                             # PDG code of the neutrino.
         "position.0",                           # Position of the neutrino interaction (X coordinate).
         "position.1",                           # Position of the neutrino interaction (Y coordinate).
@@ -533,7 +521,6 @@ spinetint_branches = [
         "primary_particle_counts.3",            # Number of primary particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 3.
         "primary_particle_counts.4",            # Number of primary particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 4.
         "primary_particle_counts.5",            # Number of primary particles of each type in the interaction (photon, electron, muon, pion, proton, kaon), type 5.
-#        "primary_particle_ids",                 # Primary particle IDs in the interaction (see 'id' attribute of SRParticleTruthDLP).
         "quark",                                # Hit quark in the neutrino interaction (see MCNeutrino).
         "reco_vertex.0",                        # Vertex of the interaction in detector coordinates (reco) (X coordinate).
         "reco_vertex.1",                        # Vertex of the interaction in detector coordinates (reco) (Y coordinate).
@@ -611,7 +598,6 @@ spinepart_branches = [
         "end_point.0",                          # End point (vector) of the particle (X coordinate).
         "end_point.1",                          # End point (vector) of the particle (Y coordinate).
         "end_point.2",                          # End point (vector) of the particle (Z coordinate).
-#        "fragment_ids",                        # Fragment IDs comprising the particle.
         "id",                                   # Particle ID (dense enumeration starting from 0 within the event).
         "interaction_id",                       # Parent interaction ID.
         "is_cathode_crosser",                   # Whether the particle is a cathode-crosser.
@@ -624,8 +610,6 @@ spinepart_branches = [
         "ke",                                   # Kinetic energy from best energy estimator (CSDA, calorimetric, or MCS).
         "length",                               # Length of the particle.
         "mass",                                 # Mass of the particle (according to assigned PID).
-#        "match_ids",                           # Particle IDs of the considered matches (correspond to true particle IDs).
-#        "match_overlaps",                      # Intersection over union (IoU) of space points of the considered matches.
         "mcs_ke",                               # Multiple Coulomb scattering kinetic energy.
         "mcs_ke_per_pid.0",                     # MCS kinetic energy for PID 0.
         "mcs_ke_per_pid.1",                     # MCS kinetic energy for PID 1.
@@ -633,7 +617,6 @@ spinepart_branches = [
         "mcs_ke_per_pid.3",                     # MCS kinetic energy for PID 3.
         "mcs_ke_per_pid.4",                     # MCS kinetic energy for PID 4.
         "mcs_ke_per_pid.5",                     # MCS kinetic energy for PID 5.
-#        "module_ids",                          # Module IDs (cryostat) of the particle.
         "momentum.0",                           # Momentum (vector) of the particle (X coordinate).
         "momentum.1",                           # Momentum (vector) of the particle (Y coordinate).
         "momentum.2",                           # Momentum (vector) of the particle (Z coordinate).
@@ -647,7 +630,6 @@ spinepart_branches = [
         "pid_scores.3",                         # PID 3 softmax scores.
         "pid_scores.4",                         # PID 4 softmax scores.
         "pid_scores.5",                         # PID 5 softmax scores.
-#        "ppn_ids",                             # PPN IDs of the particle.
         "primary_scores.0",                     # Primary score for PID 0.
         "primary_scores.1",                     # Primary score for PID 1.
         "shape",                                # Semantic type of the particle (see Shape_t enumeration).
@@ -699,7 +681,6 @@ spinetpart_branches = [
         "calo_ke",                              # Calorimetric kinetic energy.
         "cathode_offset",                       # Distance from the cathode [cm].
 #        "children_counts",                     # Number of children of the particle.
-#        "children_id",                         # List of particle ID of children particles.
 #        "creation_process",                    # Geant4 creation process associated with the particle (see MCParticle).
         "csda_ke",                              # Continuous-slowing-down-approximation kinetic energy.
         "csda_ke_per_pid.0",                    # CSDA kinetic energy per PID (PID 0).
@@ -733,7 +714,6 @@ spinetpart_branches = [
         "first_step.0",                         # X coordinate of the first step of the particle.
         "first_step.1",                         # Y coordinate of the first step oftheparticle.
         "first_step.2",                         # Z coordinate of the first stepoftheparticle.
-#        "fragment_ids",                        # Fragment IDs comprising the particle.
         "group_id",                             # Group ID of the particle.
         "group_primary",                        # Whether the particle is a primary within its group.
         "id",                                   # Particle ID (dense enumeration starting from 0 within the event).
@@ -752,8 +732,6 @@ spinetpart_branches = [
         "last_step.2",                          # Z coordinate of the coordinates of the last step of the particle.
         "length",                               # Length of the particle.
         "mass",                                 # Mass of the particle.
-#        "match_ids",                           # Particle IDs of the considered matches (correspond to reco particle IDs).
-#        "match_overlaps",                      # Intersection over union (IoU) of space points of the considered matches.
         "mcs_ke",                               # Multiple Coulomb scattering kinetic energy.
         "mcs_ke_per_pid.0",                     # MCS kinetic energy per PID.
         "mcs_ke_per_pid.1",                     # MCS kinetic energy per PID.
@@ -763,14 +741,12 @@ spinetpart_branches = [
         "mcs_ke_per_pid.5",                     # MCS kinetic energy per PID.
         "mcst_index",                           # MCST index.
         "mct_index",                            # Index of the particle in the original MCTruth array.
-#        "module_ids",                          # Module IDs (cryostat) of the particle.
         "momentum.0",                           # Mmomentum (vector) of the particle (X coordinate).
         "momentum.1",                           # Momentum (vector) of the particle (Y coordinate).
         "momentum.2",                           # Momentum (vector) of the particle (Z coordinate).
         "nu_id",                                # Neutrino ID (-1 = not a neutrino, 0 = first neutrino, 1 = second neutrino, etc.).
         "num_fragments",                        # Number of particle fragments.
         "num_voxels",                           # Number of voxels comprising the particle.
-#        "orig_children_id",                    # Original ID of the children particles.
         "orig_group_id",                        # Original group ID of the particle.
         "orig_id",                              # Original ID of the particle.
         "orig_interaction_id",                  # Interaction ID as it was stored in the parent LArCV file under the interaction_id attribute.
@@ -817,26 +793,26 @@ spinetpart_branches = [
 
 
 spinetpart_childrenid_branches = [
-    spinetpart + "children_id"              # List of particle ID of children particles.
+    spinetpart + "children_id"                  # List of particle ID of children particles.
 ]
 
 spinetpart_fragmentids_branches = [
-    spinetpart + "fragment_ids"             # Fragment IDs comprising the particle.
+    spinetpart + "fragment_ids"                 # Fragment IDs comprising the particle.
 ]
 
 spinetpart_matched_branches = [
-    spinetpart + "match_ids"                # Particle IDs of the considered matches (correspond to reco particle IDs).
+    spinetpart + "match_ids"                    # Particle IDs of the considered matches (correspond to reco particle IDs).
 ]
 
 spinetpart_matchovrlp_branches = [
-    spinetpart + "match_overlaps"           # Intersection over union (IoU) of space points of the considered matches.
+    spinetpart + "match_overlaps"               # Intersection over union (IoU) of space points of the considered matches.
 ]
 
 spinetpart_moduleids_branches = [
-    spinetpart + "module_ids"               # Module IDs (cryostat) of the particle.
+    spinetpart + "module_ids"                   # Module IDs (cryostat) of the particle.
 ]
 
 spinetpart_originchildrenid_branches = [
-    spinetpart + "orig_children_id"         # Original ID of the children particles.
+    spinetpart + "orig_children_id"             # Original ID of the children particles.
 ]
 

--- a/makedf/branches.py
+++ b/makedf/branches.py
@@ -517,11 +517,13 @@ eparticlebranches = [
 ]
 
 etruthpart = "rec.dlp_true.particles."
-etrueparticlebranches = [k.replace(epart, etruthpart) for k in eparticlebranches if "pid_scores" not in k and "start_dedx" not in k]
+etrueparticlebranches = [etruthpart + "track_id"] + [k.replace(epart, etruthpart) for k in eparticlebranches if "pid_scores" not in k and "start_dedx" not in k]
 
 eparticlematchedbranches = [
     epart + "match_ids",
-    epart + "match_overlaps",
+#    epart + "match_overlaps",
 ]
 
-
+eparticlematchovrlpbranches = [
+    epart + "match_overlaps"
+]

--- a/makedf/branches.py
+++ b/makedf/branches.py
@@ -384,146 +384,140 @@ stubhitbranches = [
     "rec.slc.reco.stub.planes.hits.wire",
 ]
 
-eslc = "rec.dlp."
-
-eslcbranches = [
-#    eslc + "is_neutrino",
-#    eslc + "nu_id",
-    eslc + "num_particles",
-#    eslc + "num_primaries",
-    eslc + "vertex.0",
-    eslc + "vertex.1",
-    eslc + "vertex.2",
+# SPINE branches
+# - SPINE reco interaction branches
+spineint = "rec.dlp."
+spineintbranches = [
+    spineint + b for b in [
+    #    "is_neutrino",
+    #    "nu_id",
+    #    "id",
+        "num_particles",
+    #    "num_primaries",
+        "vertex.0",
+        "vertex.1",
+        "vertex.2",
+    #    "is_cathode_crosser",
+    #    "is_time_contained",
+    #    "is_fiducial",
+    #    "is_flash_matched",
+    #    "is_truth",
+    #    "num_particles",
+    #    "num_primary_particles",
+    #    "flash_hypo_pe",
+    #    "flash_total_pe",
+    ]
 ]
 
-eslcmatchedbranches = [
-    eslc + "match_ids", # "match"
+spineintflashbranches = [
+    spineint + b for b in [
+        "flash_scores",
+        "flash_times"
+    ]
 ]
 
-eslcmatchovrlpbranches = [
-    eslc + "match_overlaps", # "match_overlap"
+spineintmatchedbranches = [
+    spineint + "match_ids",
 ]
 
-inter = "rec.dlp."
-
-interbranches = [
-    inter + "id",
-    inter + "is_cathode_crosser",
-    inter + "is_time_contained",
-    inter + "is_contained",
-    inter + "is_fiducial",
-    inter + "is_flash_matched",
-    inter + "is_truth",
-    inter + "num_particles",
-    inter + "num_primary_particles",
-    inter + "vertex.0",
-    inter + "vertex.1",
-    inter + "vertex.2",
-    inter + "flash_hypo_pe",
-    inter + "flash_total_pe",
+spineintmatchovrlpbranches = [
+    spineint + "match_overlaps",
 ]
 
-flashinterbranches = [
-    inter + "flash_scores",
-    inter + "flash_times",
+# - SPINE true interaction branches
+spinetint = "rec.dlp_true."
+
+spinetintbranches = [
+    spinetint + b for b in [
+        "id",
+        "nu_id",
+        "current_type",
+        "energy_init",
+        "energy_transfer",
+        "num_particles",
+        "num_primary_particles",
+        "inelasticity",
+        "interaction_mode",
+        "interaction_type",
+        "is_cathode_crosser",
+        "is_time_contained",
+        "is_contained",
+        "is_fiducial",
+        "lepton_p",
+        "lepton_pdg_code",
+        "mct_index"
+    ]
 ]
 
-intermatchedbranches = [
-    inter + "match_ids",
+# - SPINE reco particle branches
+spinepart = "rec.dlp.particles."
+
+spinepartbranches = [
+    spinepart + b for b in [
+        "calo_ke",
+        "cathode_offset",
+        # "chi2_per_pid.0",
+        # "chi2_per_pid.1",
+        # "chi2_per_pid.2",
+        # "chi2_per_pid.3",
+        # "chi2_per_pid.4",
+        # "chi2_per_pid.5",
+        # "chi2_pid",
+        "end_point.0",
+        "end_point.1",
+        "end_point.2",
+        "end_dir.0",
+        "end_dir.1",
+        "end_dir.2",
+        "interaction_id",
+        "id",
+        "is_contained",
+        "is_primary",
+        "is_valid",
+        "length",
+        "csda_ke",
+        "csda_ke_per_pid.0",
+        "csda_ke_per_pid.1",
+        "csda_ke_per_pid.2",
+        "csda_ke_per_pid.3",
+        "csda_ke_per_pid.4",
+        "csda_ke_per_pid.5",
+        "ke",
+        "p",
+        "momentum.0",
+        "momentum.1",
+        "momentum.2",
+        "mcs_ke",
+        "mcs_ke_per_pid.0",
+        "mcs_ke_per_pid.1",
+        "mcs_ke_per_pid.2",
+        "mcs_ke_per_pid.3",
+        "mcs_ke_per_pid.4",
+        "mcs_ke_per_pid.5",
+        "pid",
+        "pid_scores.0",
+        "pid_scores.1",
+        "pid_scores.2",
+        "pid_scores.3",
+        "pid_scores.4",
+        "start_point.0",
+        "start_point.1",
+        "start_point.2",
+        "start_dir.0",
+        "start_dir.1",
+        "start_dir.2",
+        "start_dedx"
+    ]
 ]
 
-intermatchovrlpbranches = [
-    inter + "match_overlaps",
+spinepartmatchedbranches = [
+    spinepart + "match_ids",
 ]
 
-etruthint = "rec.dlp_true."
-
-etruthintbranches = [
-    etruthint + "id",
-    etruthint + "nu_id",
-    etruthint + "current_type",
-    etruthint + "energy_init",
-    etruthint + "energy_transfer",
-    etruthint + "num_particles",
-    etruthint + "num_primary_particles",
-    etruthint + "inelasticity",
-    etruthint + "interaction_mode",
-    etruthint + "interaction_type",
-    etruthint + "is_cathode_crosser",
-    etruthint + "is_time_contained",
-    etruthint + "is_contained",
-    etruthint + "is_fiducial",
-    etruthint + "lepton_p",
-    etruthint + "lepton_pdg_code",
-    etruthint + "mct_index",
+spinepartmatchovrlpbranches = [
+    spinepart + "match_overlaps"
 ]
 
-epart = "rec.dlp.particles."
-
-eparticlebranches = [
-    epart + "calo_ke",
-    epart + "cathode_offset",
-    # epart + "chi2_per_pid.0",
-    # epart + "chi2_per_pid.1",
-    # epart + "chi2_per_pid.2",
-    # epart + "chi2_per_pid.3",
-    # epart + "chi2_per_pid.4",
-    # epart + "chi2_per_pid.5",
-    # epart + "chi2_pid",
-    epart + "end_point.0",
-    epart + "end_point.1",
-    epart + "end_point.2",
-    epart + "end_dir.0",
-    epart + "end_dir.1",
-    epart + "end_dir.2",
-    epart + "interaction_id",
-    epart + "id",
-    epart + "is_contained",
-    epart + "is_primary",
-    epart + "is_valid",
-    epart + "length",
-    epart + "csda_ke",
-    epart + "csda_ke_per_pid.0",
-    epart + "csda_ke_per_pid.1",
-    epart + "csda_ke_per_pid.2",
-    epart + "csda_ke_per_pid.3",
-    epart + "csda_ke_per_pid.4",
-    epart + "csda_ke_per_pid.5",
-    epart + "ke",
-    epart + "p",
-    epart + "momentum.0",
-    epart + "momentum.1",
-    epart + "momentum.2",
-    epart + "mcs_ke",
-    epart + "mcs_ke_per_pid.0",
-    epart + "mcs_ke_per_pid.1",
-    epart + "mcs_ke_per_pid.2",
-    epart + "mcs_ke_per_pid.3",
-    epart + "mcs_ke_per_pid.4",
-    epart + "mcs_ke_per_pid.5",
-    epart + "pid",
-    epart + "pid_scores.0",
-    epart + "pid_scores.1",
-    epart + "pid_scores.2",
-    epart + "pid_scores.3",
-    epart + "pid_scores.4",
-    epart + "start_point.0",
-    epart + "start_point.1",
-    epart + "start_point.2",
-    epart + "start_dir.0",
-    epart + "start_dir.1",
-    epart + "start_dir.2",
-    epart + "start_dedx"
-]
-
-etruthpart = "rec.dlp_true.particles."
-etrueparticlebranches = [etruthpart + "track_id"] + [k.replace(epart, etruthpart) for k in eparticlebranches if "pid_scores" not in k and "start_dedx" not in k]
-
-eparticlematchedbranches = [
-    epart + "match_ids",
-#    epart + "match_overlaps",
-]
-
-eparticlematchovrlpbranches = [
-    epart + "match_overlaps"
-]
+# - SPINE true particle branches
+spinetpart = "rec.dlp_true.particles."
+spinetpartbranches = [spinetpart + "track_id"] + [k.replace(spinepart, spinetpart) for k in spinepartbranches if "pid_scores" not in k and "start_dedx" not in k]

--- a/makedf/makedf.py
+++ b/makedf/makedf.py
@@ -594,22 +594,20 @@ def make_spine_df(f, trkDistCut=-1, requireFiducial=True, **trkArgs):
     spine_df = multicol_merge(spine_int_df, spine_part_df, left_index=True, right_index=True, how="right", validate="one_to_many")
 
     # Add distance-to-vertex particle column to SPINE dataframe
-    spine_df = multicol_add(spine_df, dmagdf(spine_df.vertex, spine_df.particle.start_point).rename("dist_to_vertex"))
+    spine_df = multicol_add(spine_df, dmagdf(spine_df[("rec", "dlp", "vertex")], spine_df[("particle", "start_point")]).rename(("dist_to_vertex", "")))
 
     # Check and apply cuts
     if trkDistCut > 0:
         spine_df = spine_df[spine_df.dist_to_vertex < trkDistCut]
     if requireFiducial:
-        spine_df = spine_df[InFV(spine_df.vertex, 50)]
+        spine_df = spine_df[InFV(spine_df[("rec", "dlp", "vertex")], 50)]
 
     return spine_df
 
 def make_spine_int_df(f):
-    eslcdf = loadbranches(f["recTree"], spineintbranches)
-    eslcdf = eslcdf.rec.dlp
+    eslcdf = loadbranches(f["recTree"], spineint_branches)
 
-    etintdf = loadbranches(f["recTree"], spinetintbranches)
-    etintdf = etintdf.rec.dlp_true
+    etintdf = loadbranches(f["recTree"], spinetint_branches)
     
     # match to the truth info
     mcdf = make_mcdf(f)
@@ -619,19 +617,19 @@ def make_spine_int_df(f):
     # Do matching
     # 
     # First get the ML true particle IDs matched to each reco particle
-    eslc_matchdf = loadbranches(f["recTree"], spineintmatchedbranches)
-    eslc_match_overlap_df = loadbranches(f["recTree"], spineintmatchovrlpbranches)
+    eslc_matchdf = loadbranches(f["recTree"], spineint_matched_branches)
+    eslc_match_overlap_df = loadbranches(f["recTree"], spineint_matchovrlp_branches)
     eslc_match_overlap_df.index.names = eslc_matchdf.index.names
 
     eslc_matchdf = multicol_merge(eslc_matchdf, eslc_match_overlap_df, left_index=True, right_index=True, how="left", validate="one_to_one")
     eslc_matchdf = eslc_matchdf.rec.dlp
 
     # Then use bestmatch.match to get the nu ids in etintdf
-    eslc_matchdf_wids = pd.merge(eslc_matchdf, etintdf, left_on=["entry", "match_ids"], right_on=["entry", "id"], how="left")
+    eslc_matchdf_wids = multicol_merge(eslc_matchdf, etintdf, left_on=["entry", "match_ids"], right_on=["entry",  ("rec", "dlp_true", "id", "")], how="left")
     eslc_matchdf_wids.index = eslc_matchdf.index
 
     # Now use nu_ids to get the true interaction information
-    eslc_matchdf_trueints = multicol_merge(eslc_matchdf_wids, mcdf, left_on=["entry", "nu_id"], right_index=True, how="left")
+    eslc_matchdf_trueints = multicol_merge(eslc_matchdf_wids, mcdf, left_on=["entry", ("rec", "dlp_true", "nu_id")], right_index=True, how="left")
     eslc_matchdf_trueints.index = eslc_matchdf_wids.index
 
     # first match is best match
@@ -642,54 +640,33 @@ def make_spine_int_df(f):
 
     eslcdf_withmc = multicol_merge(eslcdf, bestmatch, left_index=True, right_index=True, how="left")
 
-    # Fix position names (I0, I1, I2) -> (x, y, z)
-    def mappos(s):
-        if s == "I0": return "x"
-        if s == "I1": return "y"
-        if s == "I2": return "z"
-        return s
-    def fixpos(c):
-        if c[0] not in ["end_point", "start_point", "start_dir", "vertex", "momentum"]: return c
-        return tuple([c[0]] + [mappos(c[1])] + list(c[2:]))
-
-    eslcdf_withmc.columns = pd.MultiIndex.from_tuples([fixpos(c) for c in eslcdf_withmc.columns])
+    cols_to_rename = ["momentum", "end_point", "start_point", "start_dir", "end_dir", "reco_vertex", "vertex"]
+    rename_to_XYZ(eslcdf_withmc, cols_to_rename)
 
     return eslcdf_withmc
 
 def make_spine_part_df(f):
     # Load SPINE reco particle (rec.dlp.particle.) branches
-    spine_part_df = loadbranches(f["recTree"], spinepartbranches)
+    spine_part_df = loadbranches(f["recTree"], spinepart_branches)
     spine_part_df = spine_part_df.rec.dlp.particles
-    #print("\nSPINE_PART_DF")
-    #print("\n".join(str(col) for col in spine_part_df.columns))
 
     # Load SPINE true particle (rec.dlp_true.particle.) branches
-    spine_true_part_df = loadbranches(f["recTree"], spinetpartbranches)
+    spine_true_part_df = loadbranches(f["recTree"], spinetpart_branches)
     spine_true_part_df = spine_true_part_df.rec.dlp_true.particles
     spine_true_part_df_prefix = "strue" # SPINE true
     add_upper_level_to_df(spine_true_part_df_prefix, spine_true_part_df)
-    #spine_true_part_df.columns = pd.MultiIndex.from_tuples(
-    #    [(spine_true_part_df_prefix,) + col for col in spine_true_part_df.columns]
-    #)
     spine_true_part_df.columns = [s for s in spine_true_part_df.columns]
-    #print("\nSPINE_TRUE_PART_DF")
-    #print("\n".join(str(col) for col in spine_true_part_df.columns))
 
     # Load true particle branches
     true_part_df = loadbranches(f["recTree"], trueparticlebranches)
     true_part_df = true_part_df.rec.true_particles
     true_part_df_prefix = "true"
     add_upper_level_to_df(true_part_df_prefix, true_part_df)
-    #true_part_df.columns = pd.MultiIndex.from_tuples(
-    #    [(true_part_df_prefix,) + col for col in true_part_df.columns]
-    #)
-    #print("\nTRUE_PART_DF")
-    #print("\n".join(str(col) for col in true_part_df))
 
     # ============ Do matching between SPINE true particles and reco ID matched ============ #
     # - Load match_ids and overlaps branches
-    spine_part_match_df = loadbranches(f["recTree"], spinepartmatchedbranches)
-    spine_part_match_overlap_df = loadbranches(f["recTree"], spinepartmatchovrlpbranches)
+    spine_part_match_df = loadbranches(f["recTree"], spinepart_matched_branches)
+    spine_part_match_overlap_df = loadbranches(f["recTree"], spinepart_matchovrlp_branches)
     # - Dataframe with match ids and overlaps
     spine_part_match_overlap_df.index.names = spine_part_match_df.index.names
     spine_part_match_df = multicol_merge(spine_part_match_df, spine_part_match_overlap_df, left_index=True, right_index=True, how="left", validate="one_to_one")
@@ -697,16 +674,12 @@ def make_spine_part_df(f):
     # - Get the best match (highest match_overlap), assume it's sorted
     spine_bestmatch_df = spine_part_match_df.groupby(level=list(range(spine_part_match_df.index.nlevels-1))).first()
     spine_bestmatch_df.columns = [s for s in spine_bestmatch_df.columns]
-    #print("\nSPINE_BESTMATCH_DF")
-    #print("\n".join(str(col) for col in spine_bestmatch_df.columns))
     # - Match SPINE true particles with their pair (match id - overlap)
     spine_bestmatch_wids_df = pd.merge(spine_bestmatch_df, spine_true_part_df, 
                                        left_on=["entry", "match_ids"], 
                                        right_on=["entry", (spine_true_part_df_prefix, "id", "")], 
                                        how="left")
     spine_bestmatch_wids_df.index = spine_bestmatch_df.index
-    #print("\nSPINE_BESTMATCH_WIDS_DF")
-    #print("\n".join(str(col) for col in spine_bestmatch_wids_df.columns))
     
     # ============ Match SPINE true particles dataframe with true particles dataframe ============ #
     bestmatch_true_particles_df = multicol_merge(spine_bestmatch_wids_df, true_part_df, 
@@ -714,41 +687,18 @@ def make_spine_part_df(f):
                                                  right_on=["entry", (true_part_df_prefix, "G4ID", "")],
                                                  how="left")
     bestmatch_true_particles_df.index = spine_bestmatch_wids_df.index
-    #print("\nBESTMATCH_TRUE_PARTICLES_DF")
-    #print("\n".join(str(col) for col in bestmatch_true_particles_df.columns))
 
     # Fill column levels
     max_num_levels = max(bestmatch_true_particles_df.columns.nlevels, spine_part_df.columns.nlevels)
     spine_part_df.columns = pd.MultiIndex.from_tuples(
         [tuple(list(c) + [""] * (max_num_levels - len(c))) for c in spine_part_df.columns]
     ) 
-    #print("\nSPINE_PART_DF_AFTER_MERGING")
-    #print("\n".join(str(col) for col in bestmatch_true_particles_df.columns))
 
     # Add true information to SPINE reco particle dataframe
     for c in bestmatch_true_particles_df.columns:
         spine_part_df[c] = bestmatch_true_particles_df[c]
 
-    # Fix position names (I0, I1, I2) -> (x, y, z)
-    def mappos(s):
-        if s == "I0": return "x"
-        if s == "I1": return "y"
-        if s == "I2": return "z"
-        return s
-    def fixpos(c):
-        new_tuple = c
-        sub_columns = ["momentum", "end_point", "start_point", "start_dir", "end_dir", "vertex"]
-        true_prefixes = [spine_true_part_df_prefix, true_part_df_prefix]
-        if c[0] in true_prefixes:
-            if c[1] in sub_columns:
-                new_tuple = tuple([c[0]] + [c[1]] + [mappos(c[2])] + list(c[3:]))
-        else:
-            if c[0] in sub_columns:
-                new_tuple = tuple([c[0]] + [mappos(c[1])] + list(c[2:]))
-        return new_tuple
+    cols_to_rename = ["momentum", "end_point", "start_point", "start_dir", "end_dir", "vertex"] 
 
-    spine_part_df.columns = pd.MultiIndex.from_tuples(
-        [fixpos(c) for c in spine_part_df.columns]
-    )
-
+    rename_to_XYZ(spine_part_df, cols_to_rename)
     return spine_part_df

--- a/makedf/makedf.py
+++ b/makedf/makedf.py
@@ -488,12 +488,14 @@ def make_pandora_df(f, trkScoreCut=False, trkDistCut=50., cutClearCosmic=False, 
 def make_spine_df(f, trkDistCut=-1, requireFiducial=True, **trkArgs):
     # load
     partdf = make_spinepartdf(f, **trkArgs)
-    partdf.columns = pd.MultiIndex.from_tuples([tuple(["particle"] + list(c)) for c in partdf.columns])
+    #partdf.columns = pd.MultiIndex.from_tuples([tuple(["particle"] + list(c)) for c in partdf.columns])
     eslcdf = make_spineslcdf(f)
 
     # merge in tracks
-    eslcdf = multicol_merge(eslcdf, partdf, left_index=True, right_index=True, how="right", validate="one_to_many")
-    eslcdf = multicol_add(eslcdf, dmagdf(eslcdf.vertex, eslcdf.particle.start_point).rename("dist_to_vertex"))
+    #eslcdf = multicol_merge(eslcdf, partdf, left_index=True, right_index=True, how="right", validate="one_to_many")
+
+    #print(*eslcdf.columns, sep="\n")
+    #eslcdf = multicol_add(eslcdf, dmagdf(eslcdf.vertex, eslcdf.particle.start_point).rename("dist_to_vertex"))
 
     if trkDistCut > 0:
         eslcdf = eslcdf[eslcdf.dist_to_vertex < trkDistCut]
@@ -623,7 +625,8 @@ def make_spineslcdf(f):
     eslc_matchdf = eslc_matchdf.rec.dlp
 
     # Then use bestmatch.match to get the nu ids in etintdf
-    eslc_matchdf_wids = pd.merge(eslc_matchdf, etintdf, left_on=["entry", "match"], right_on=["entry", "id"], how="left")
+    #eslc_matchdf_wids = pd.merge(eslc_matchdf, etintdf, left_on=["entry", "match"], right_on=["entry", "id"], how="left")
+    eslc_matchdf_wids = pd.merge(eslc_matchdf, etintdf, left_on=["entry", "match_ids"], right_on=["entry", "id"], how="left")
     eslc_matchdf_wids.index = eslc_matchdf.index
 
     # Now use nu_ids to get the true interaction information
@@ -631,7 +634,8 @@ def make_spineslcdf(f):
     eslc_matchdf_trueints.index = eslc_matchdf_wids.index
 
     # delete unnecesary matching branches
-    del eslc_matchdf_trueints[("match", "")]
+    #del eslc_matchdf_trueints[("match", "")]
+    del eslc_matchdf_trueints[("match_ids", "")]
     del eslc_matchdf_trueints[("nu_id", "")]
     del eslc_matchdf_trueints[("id", "")]
 
@@ -668,12 +672,14 @@ def make_spinepartdf(f):
 
     etpartdf = loadbranches(f["recTree"], etrueparticlebranches)
     etpartdf = etpartdf.rec.dlp_true.particles
-    etpartdf.columns = [s for s in etpartdf.columns]
+    etpartdf.columns = [s for s in etpartdf.columns] # ???
     
+     
     # Do matching
     # 
     # First get the ML true particle IDs matched to each reco particle
     epart_matchdf = loadbranches(f["recTree"], eparticlematchedbranches)
+    """
     epart_match_overlap_df = loadbranches(f["recTree"], eparticlematchovrlpbranches)
     epart_match_overlap_df.index.names = epart_matchdf.index.names
     epart_matchdf = multicol_merge(epart_matchdf, epart_match_overlap_df, left_index=True, right_index=True, how="left", validate="one_to_one")
@@ -713,5 +719,5 @@ def make_spinepartdf(f):
         return tuple([c[0]] + [mappos(c[1])] + list(c[2:]))
 
     epartdf.columns = pd.MultiIndex.from_tuples([fixpos(c) for c in epartdf.columns])
-
+    """
     return epartdf

--- a/makedf/makedf.py
+++ b/makedf/makedf.py
@@ -488,14 +488,14 @@ def make_pandora_df(f, trkScoreCut=False, trkDistCut=50., cutClearCosmic=False, 
 def make_spine_df(f, trkDistCut=-1, requireFiducial=True, **trkArgs):
     # load
     partdf = make_spinepartdf(f, **trkArgs)
-    #partdf.columns = pd.MultiIndex.from_tuples([tuple(["particle"] + list(c)) for c in partdf.columns])
+    partdf.columns = pd.MultiIndex.from_tuples([tuple(["particle"] + list(c)) for c in partdf.columns])
     eslcdf = make_spineslcdf(f)
 
     # merge in tracks
-    #eslcdf = multicol_merge(eslcdf, partdf, left_index=True, right_index=True, how="right", validate="one_to_many")
+    eslcdf = multicol_merge(eslcdf, partdf, left_index=True, right_index=True, how="right", validate="one_to_many")
 
     #print(*eslcdf.columns, sep="\n")
-    #eslcdf = multicol_add(eslcdf, dmagdf(eslcdf.vertex, eslcdf.particle.start_point).rename("dist_to_vertex"))
+    eslcdf = multicol_add(eslcdf, dmagdf(eslcdf.vertex, eslcdf.particle.start_point).rename("dist_to_vertex"))
 
     if trkDistCut > 0:
         eslcdf = eslcdf[eslcdf.dist_to_vertex < trkDistCut]
@@ -662,40 +662,17 @@ def make_spineslcdf(f):
     return eslcdf_withmc
 
 def make_spinepartdf(f):
-    #print("SPINE REC PARTICLES eparticlebranches: ")
-    #print("\n".join(f" - {b}" for b in eparticlebranches))
     epartdf = loadbranches(f["recTree"], eparticlebranches)
-    #print("epartdf BEFORE epartdf.rec.dlp.particles:")
-    #print("\n".join(f" - {c}" for c in epartdf.columns))
     epartdf = epartdf.rec.dlp.particles
-    print("epartdf AFTER epartdf.rec.dlp.particles:")
-    print("\n".join(f" - {c}" for c in epartdf.columns))
-    print("SHAPE: ", epartdf.shape)
 
-    #print("TRUE PARTICLES trueparticlebranches: ")
-    #print("\n".join(f" - {b}" for b in trueparticlebranches))
     tpartdf = loadbranches(f["recTree"], trueparticlebranches)
-    #print("tpartdf BEFORE tpartdf.rec.true_particles")
-    #print("\n".join(f" - {c}" for c in tpartdf.columns))
     tpartdf = tpartdf.rec.true_particles
-    print("tpartdf AFRER tpartdf.rec.true_particles")
-    print("\n".join(f" - {c}" for c in tpartdf.columns))
-    print("SHAPE: ", tpartdf.shape)
     # cut out EMShowerDaughters
     # tpartdf = tpartdf[(tpartdf.parent == 0)]
 
-    #print("SPINE TRUE PARTICLES etrueparticlebranches: ")
-    #print("\n".join(f" - {b}" for b in etrueparticlebranches))
     etpartdf = loadbranches(f["recTree"], etrueparticlebranches)
-    #print("etpartdf BEFORE etpartdf.rec.dlp_true.particles")
-    #print("\n".join(f" - {c}" for c in etpartdf.columns))
     etpartdf = etpartdf.rec.dlp_true.particles
-    #print("etpartdf AFTER etpartdf.rec.dlp_true.particles")
-    #print("\n".join(f" - {c}" for c in etpartdf.columns))
     etpartdf.columns = [s for s in etpartdf.columns]
-    print("etpartdf AFTER etpartdf.columns = [s for s in etpartdf.columns]")
-    print("\n".join(f" - {c}" for c in etpartdf.columns))
-    print("SHAPE: ", etpartdf.shape)
      
     # Do matching
     # 
@@ -703,44 +680,21 @@ def make_spinepartdf(f):
     epart_matchdf = loadbranches(f["recTree"], eparticlematchedbranches)
     epart_match_overlap_df = loadbranches(f["recTree"], eparticlematchovrlpbranches)
     epart_match_overlap_df.index.names = epart_matchdf.index.names
-    #print("\nepart_matchdf index names:", epart_matchdf.index.names)
-    #print("epart_match_overlap_df index names:", epart_match_overlap_df.index.names)
-    #print(epart_matchdf.head(10))
-    #print(epart_match_overlap_df.head(10))
 
     epart_matchdf = multicol_merge(epart_matchdf, epart_match_overlap_df, left_index=True, right_index=True, how="left", validate="one_to_one")
 
-    #print("\nepart_matchdf AFTER MERGING")
-    #print(epart_matchdf.head(10))
-    #print("\n".join(f" - {c}" for c in epart_matchdf.columns))
     epart_matchdf = epart_matchdf.rec.dlp.particles
     # get the best match (highest match_overlap), assume it's sorted
 
-    #print("epartdf before group by")
-    #print("\n".join(f" - {c}" for c in epart_matchdf.columns))
-    #print(epart_matchdf.head(10))
     bestmatch = epart_matchdf.groupby(level=list(range(epart_matchdf.index.nlevels-1))).first()
-
-    #print("bestmatch after groupby")
-    #print("\n".join(f" - {c}" for c in bestmatch.columns))
-    #print(bestmatch.head(10))
-    #print(bestmatch.shape)
     bestmatch.columns = [s for s in bestmatch.columns]
-    #print(bestmatch.shape)
 
     # Then use betmatch.match to get the G4 track IDs in etpartdf
     #bestmatch_wids = pd.merge(bestmatch, etpartdf, left_on=["entry", "match"], right_on=["entry", "id"], how="left")
     bestmatch_wids = pd.merge(bestmatch, etpartdf, left_on=["entry", "match_ids"], right_on=["entry", ("id", "")], how="left")
-    #print("bestmatch_wids after merging")
-    #print("\n".join(f" - {c}" for c in bestmatch_wids.columns))
-    #print(bestmatch_wids.T.head(10))
-    #print(bestmatch_wids.head(10))
-    #print(bestmatch_wids.shape)
     bestmatch_wids.index = bestmatch.index
 
     # Now use the G4 track IDs to get the true particle information
-    #print("Columnas tpartdf:", tpartdf.columns.tolist())
-    #print("tpartdf shape: ", tpartdf.shape)
     #bestmatch_trueparticles = multicol_merge(bestmatch_wids, tpartdf, left_on=["entry", "track_id"], right_on=["entry", ("G4ID", "")], how="left")
     bestmatch_trueparticles = multicol_merge(bestmatch_wids, tpartdf, left_on=["entry", ("track_id", "")], right_on=["entry", ("G4ID", "")], how="left")
     bestmatch_trueparticles.index = bestmatch_wids.index
@@ -752,32 +706,16 @@ def make_spinepartdf(f):
     del bestmatch_trueparticles[("id", "")]
 
     # add extra level to epartdf columns
-    print("ADD EXTRA LEVEL TO EPARTDF")
-    print("\n".join(f" - {c}" for c in epartdf.columns))
-    print(epartdf.head(10))
-    print(epartdf.shape)
     #epartdf.columns = pd.MultiIndex.from_tuples([tuple(list(c) + [""]) for c in epartdf.columns])
     epartdf.columns = pd.MultiIndex.from_tuples(
         [tuple(list(c) + [""] * (5 - len(c))) for c in epartdf.columns]
     ) 
-    print("AFTER ADD EXTRA LEVEL")
-    print("\n".join(f" - {c}" for c in epartdf.columns))
-    print(epartdf.head(10))
-    print(epartdf.shape)
 
     # put everything in epartdf
-    print("BESTMATCH_TRUEPARTICLES DF")
-    print("\n".join(f" - {c}" for c in bestmatch_trueparticles.columns))
-    print(bestmatch_trueparticles.head(10))
-    print(bestmatch_trueparticles.shape)
     for c in bestmatch_trueparticles.columns:
     #    epartdf[tuple(["truth"] + list(c))] = bestmatch_trueparticles[c]
         tuple_key = ("truth",) + c
         epartdf[tuple_key] = bestmatch_trueparticles[c]
-    print("FINAL DF")
-    print("\n".join(f" - {c}" for c in epartdf.columns))
-    print(epartdf.head(10))
-    print(epartdf.shape)
     # Fix position names (I0, I1, I2) -> (x, y, z)
     def mappos(s):
         if s == "I0": return "x"
@@ -799,10 +737,5 @@ def make_spinepartdf(f):
 
 
     epartdf.columns = pd.MultiIndex.from_tuples([fixpos(c) for c in epartdf.columns])
-
-    print("FINAL DF AFTER RENAMING")
-    print("\n".join(f" - {c}" for c in epartdf.columns))
-    print(epartdf.head(10))
-    print(epartdf.shape)
 
     return epartdf

--- a/makedf/makedf.py
+++ b/makedf/makedf.py
@@ -589,7 +589,6 @@ def make_all_spine_df(f, get_best_match=True, **trkArgs):
 
     # Load SPINE particles dataframe
     spine_part_df = make_spine_part_df(f, get_best_match, **trkArgs)
-    add_upper_level_to_df("particle", spine_part_df)
 
     # Merge both dataframes
     spine_df = multicol_merge(spine_int_df, spine_part_df, left_index=True, right_index=True, how="right", validate="one_to_many")
@@ -644,7 +643,6 @@ def make_spine_part_mcpart_df(f, get_best_match=True):
     mcpart_df = loadbranches(f["recTree"], trueparticlebranches)
 
     # Match SPINE particles dataframe with MC (Geant4) particles dataframe.
-
     spinepart_mcpart_df = multicol_merge(
         lhs=spinepart_df.reset_index(level=[1, 2]),
         rhs=mcpart_df.reset_index(level=[1]),
@@ -687,11 +685,11 @@ def make_spine_int_df(f, get_best_match=True):
         validate="one_to_one"
     )
 
+    # If we want to get the best match, first sorts the match_overlaps column and gets the first value.
+    # matches_df, validate_matched and validate_matched_with_true values change depending on get_best_match value.
     matches_df = spineint_matches_df
     validate_matched = "many_to_one"
     validate_matched_with_true = "many_to_many"
-
-    # If we want to get the best match, first sorts the match_overlaps column and gets the first value.
     if get_best_match:
         # Find best match for each Multi-Index.
         spineint_best_matches_df = (
@@ -758,6 +756,8 @@ def make_spine_part_df(f, get_best_match=True):
         validate="one_to_one"
     )
 
+    # If we want to get the best match, first sorts the match_overlaps column and gets the first value.
+    # matches_df, validate_matched and validate_matched_with_true values change depending on get_best_match value.
     matches_df = spinepart_matches_df
     validate_matched = "many_to_one"
     validate_matched_with_true = "many_to_many"
@@ -782,6 +782,7 @@ def make_spine_part_df(f, get_best_match=True):
         validate=validate_matched
     )
 
+    # Match reco SPINE particles with true SPINE particles.
     spinepart_matched_with_true_df = multicol_merge(
         lhs=spinepart_matched_df.reset_index(level=[1, 2]),
         rhs=spinetpart_df.reset_index(level=[1, 2]),
@@ -791,6 +792,7 @@ def make_spine_part_df(f, get_best_match=True):
         validate=validate_matched_with_true
     ).set_index(["rec.dlp..index", "rec.dlp.particles..index"], append=True)
 
+    # Rename I0-I1-I2 variables to x-y-z
     cols_to_rename = ["momentum", "end_point", "start_point", "start_dir", "end_dir", "vertex"] 
     rename_to_XYZ(spinepart_matched_with_true_df, cols_to_rename)
 

--- a/makedf/makedf.py
+++ b/makedf/makedf.py
@@ -603,10 +603,10 @@ def make_spine_df(f, trkDistCut=-1, requireFiducial=True, **trkArgs):
     return eslcdf
 
 def make_spineslcdf(f):
-    eslcdf = loadbranches(f["recTree"], eslcbranches)
+    eslcdf = loadbranches(f["recTree"], spineintbranches)
     eslcdf = eslcdf.rec.dlp
 
-    etintdf = loadbranches(f["recTree"], etruthintbranches)
+    etintdf = loadbranches(f["recTree"], spinetintbranches)
     etintdf = etintdf.rec.dlp_true
     
     # match to the truth info
@@ -617,8 +617,8 @@ def make_spineslcdf(f):
     # Do matching
     # 
     # First get the ML true particle IDs matched to each reco particle
-    eslc_matchdf = loadbranches(f["recTree"], eslcmatchedbranches)
-    eslc_match_overlap_df = loadbranches(f["recTree"], eslcmatchovrlpbranches)
+    eslc_matchdf = loadbranches(f["recTree"], spineintmatchedbranches)
+    eslc_match_overlap_df = loadbranches(f["recTree"], spineintmatchovrlpbranches)
     eslc_match_overlap_df.index.names = eslc_matchdf.index.names
 
     eslc_matchdf = multicol_merge(eslc_matchdf, eslc_match_overlap_df, left_index=True, right_index=True, how="left", validate="one_to_one")
@@ -660,7 +660,7 @@ def make_spineslcdf(f):
     return eslcdf_withmc
 
 def make_spinepartdf(f):
-    epartdf = loadbranches(f["recTree"], eparticlebranches)
+    epartdf = loadbranches(f["recTree"], spinepartbranches)
     epartdf = epartdf.rec.dlp.particles
 
     tpartdf = loadbranches(f["recTree"], trueparticlebranches)
@@ -668,15 +668,15 @@ def make_spinepartdf(f):
     # cut out EMShowerDaughters
     # tpartdf = tpartdf[(tpartdf.parent == 0)]
 
-    etpartdf = loadbranches(f["recTree"], etrueparticlebranches)
+    etpartdf = loadbranches(f["recTree"], spinetpartbranches)
     etpartdf = etpartdf.rec.dlp_true.particles
     etpartdf.columns = [s for s in etpartdf.columns]
      
     # Do matching
     # 
     # First get the ML true particle IDs matched to each reco particle
-    epart_matchdf = loadbranches(f["recTree"], eparticlematchedbranches)
-    epart_match_overlap_df = loadbranches(f["recTree"], eparticlematchovrlpbranches)
+    epart_matchdf = loadbranches(f["recTree"], spinepartmatchedbranches)
+    epart_match_overlap_df = loadbranches(f["recTree"], spinepartmatchovrlpbranches)
     epart_match_overlap_df.index.names = epart_matchdf.index.names
 
     epart_matchdf = multicol_merge(epart_matchdf, epart_match_overlap_df, left_index=True, right_index=True, how="left", validate="one_to_one")

--- a/makedf/makedf.py
+++ b/makedf/makedf.py
@@ -583,75 +583,45 @@ def make_stubs(f, det="ICARUS"):
 
     #return pd.concat(df_tosave, axis=1)
 
-def make_spine_df(f, trkDistCut=-1, requireFiducial=True, **trkArgs):
+def make_all_spine_df(f, get_best_match=True, **trkArgs):
     # Load SPINE interactions dataframe
-    spine_int_df = make_spine_int_df(f)
+    spine_int_df = make_spine_int_df(f, get_best_match)
 
     # Load SPINE particles dataframe
     spine_part_df = make_spine_part_df(f, **trkArgs)
-    spine_part_df.columns = pd.MultiIndex.from_tuples([tuple(["particle"] + list(c)) for c in spine_part_df.columns])
+    add_upper_level_to_df("particle", spine_part_df)
 
     # Merge both dataframes
     spine_df = multicol_merge(spine_int_df, spine_part_df, left_index=True, right_index=True, how="right", validate="one_to_many")
 
-    # Add distance-to-vertex particle column to SPINE dataframe
-    spine_df = multicol_add(spine_df, dmagdf(spine_df[("rec", "dlp", "vertex")], spine_df[("particle", "start_point")]).rename(("dist_to_vertex", "")))
-
-    # Check and apply cuts
-    if trkDistCut > 0:
-        spine_df = spine_df[spine_df.dist_to_vertex < trkDistCut]
-    if requireFiducial:
-        spine_df = spine_df[InFV(spine_df[("rec", "dlp", "vertex")], 50)]
-
     return spine_df
 
-def make_spine_int_df(f):
+def make_spine_int_mcnu_df(f, get_best_match=True):
     """
-    SPINE dataframe maker which containes all SPINE reco and true variables matched with MC nu dataframe.
+    SPINE dataframe maker which containes all SPINE reco and true variables 
+    matched with MC nu dataframe.
     
     :param f: file handle to the input ROOT file
     :type f: uproot4.open file handle
 
-    :return: SPINE events dataframe
+    :return: SPINE + MC nu events dataframe
     :rtype: pd.DataFrame   
     """
 
-    # Get reco tree from file.
-    rec_tree = f["recTree"]
-
-    # Load SPINE interaction and matches branches.
-    spinetint_df            = loadbranches(rec_tree, spinetint_branches)
-    spineint_df             = loadbranches(rec_tree, spineint_branches)
-    spineint_matchids_df    = loadbranches(rec_tree, spineint_matched_branches)
-    spineint_matchovrlp_df  = loadbranches(rec_tree, spineint_matchovrlp_branches)
-
-    # Load the MC dataframe.
+    # Load SPINE and MC dataframes.
+    spineint_df = make_spine_int_df(f, get_best_match)
     mcnu_df = make_mcdf(f)
-
-    # Match match_ids and match_overlaps data.
-    spineint_matches_df = spineint_matchids_df.merge(spineint_matchovrlp_df, left_on=["entry", "rec.dlp..index", "rec.dlp.match_ids..index"], right_on=["entry", "rec.dlp..index", "rec.dlp.match_overlaps..index"], how="left")
-
-    # Match reco SPINE interactions to match_ids and match_overlaps data.
-    spineint_matched_df = multicol_merge( lhs=spineint_matches_df, rhs=spineint_df, on=["entry", "rec.dlp..index"], how="left", validate="one_to_one")
-
-    # Match reco SPINE interactions to true SPINE interactions using match_ids and match_overlaps data.
-    spineint_matched_with_true_df = multicol_merge(spineint_matched_df, spinetint_df, 
-                                                    left_on=["entry", ("rec", "dlp", "match_ids", "")], right_on=["entry", ("rec", "dlp_true", "id", "")],
-                                                    how="left", validate="many_to_one")
-    spineint_matched_with_true_df.index = spineint_matched_df.index
 
     # Match reco and true SPINE interactions with MC interactions data.
     add_upper_level_to_df("mcnu", mcnu_df)
-    spineint_matched_with_true_mcnu_df = multicol_merge(spineint_matched_with_true_df, mcnu_df, left_on=["entry", ("rec", "dlp_true", "nu_id", "")], right_index=True, how="left")
+    spineint_mcnu_df = multicol_merge(
+        lhs=spineint_df,
+        rhs=mcnu_df,
+        left_on=["entry", ("rec", "dlp_true", "mct_index", "")],
+        right_index=True,
+        how="left")
 
-    # Get best interaction matching
-    bestmatch_indices = spineint_matched_with_true_mcnu_df[("rec", "dlp", "match_overlaps", "")].groupby(level="entry").idxmax(skipna=False)
-    spine_bestmatch_df = spineint_matched_with_true_mcnu_df.loc[bestmatch_indices]
-
-    # Rename I0-I1-I2 variables to x-y-z
-    rename_to_XYZ(spine_bestmatch_df, ["momentum", "end_point", "start_point", "start_dir", "end_dir", "reco_vertex", "vertex"])
-
-    return spine_bestmatch_df
+    return spineint_mcnu_df
 
 
 def make_spine_part_df(f):
@@ -711,6 +681,78 @@ def make_spine_part_df(f):
 
     rename_to_XYZ(spine_part_df, cols_to_rename)
     return spine_part_df
+
+def make_spine_int_df(f, get_best_match=True):
+    """
+    SPINE dataframe maker which containes all SPINE reco and true variables matched with MC nu dataframe.
+    
+    :param f: file handle to the input ROOT file
+    :type f: uproot4.open file handle
+    :param get_best_match: `True` if a best match selection is needed.
+    :type get_best_match: bool
+
+    :return: SPINE events dataframe
+    :rtype: pd.DataFrame   
+    """
+    # Get reco tree from file.
+    rec_tree = f["recTree"]
+
+    # Load SPINE interaction and matches branches.
+    spinetint_df            = loadbranches(rec_tree, spinetint_branches)
+    spineint_df             = loadbranches(rec_tree, spineint_branches)
+    spineint_matchids_df    = loadbranches(rec_tree, spineint_matched_branches)
+    spineint_matchovrlp_df  = loadbranches(rec_tree, spineint_matchovrlp_branches)
+
+    # Match match_ids and match_overlaps data.
+    spineint_matches_df = spineint_matchids_df.merge(
+        spineint_matchovrlp_df,
+        left_on=["entry", "rec.dlp..index", "rec.dlp.match_ids..index"],
+        right_on=["entry", "rec.dlp..index", "rec.dlp.match_overlaps..index"],
+        how="left",
+        validate="one_to_one"
+    )
+
+    matches_df = spineint_matches_df
+    validate_matched = "many_to_one"
+    validate_matched_with_true = "many_to_many"
+
+    # If we want to get the best match, first sorts the match_overlaps column and gets the first value.
+    if get_best_match:
+        # Find best match for each Multi-Index.
+        spineint_best_matches_df = (
+            spineint_matches_df
+            .sort_values(("rec", "dlp", "match_overlaps"), ascending=False)
+            .groupby(level=["entry", "rec.dlp..index"])
+            .first()
+        )
+        matches_df = spineint_best_matches_df
+        validate_matched = "one_to_one"
+        validate_matched_with_true = "many_to_one"
+
+    # Match reco SPINE interactions to match_ids and match_overlaps data.
+    spineint_matched_df = multicol_merge(
+        lhs=matches_df,
+        rhs=spineint_df,
+        on=["entry", "rec.dlp..index"],
+        how="left",
+        validate=validate_matched
+    )
+
+    # Match reco SPINE interactions with true SPINE interactions.
+    spineint_matched_with_true_df = multicol_merge(
+        lhs=spineint_matched_df.reset_index(level=1),
+        rhs=spinetint_df.reset_index(level=1),
+        left_on=["entry", ("rec", "dlp", "match_ids", "")],
+        right_on=["entry", ("rec", "dlp_true", "id", "")],
+        how="left",
+        validate=validate_matched_with_true
+    ).set_index(("rec.dlp..index"), append=True)
+
+    # Rename I0-I1-I2 variables to x-y-z
+    cols_to_rename = ["momentum", "end_point", "start_point", "start_dir", "end_dir", "reco_vertex", "vertex"]
+    rename_to_XYZ(spineint_matched_with_true_df, cols_to_rename)
+
+    return spineint_matched_with_true_df
 
 def make_spine_flash_df(f):
     """

--- a/makedf/makedf.py
+++ b/makedf/makedf.py
@@ -1,3 +1,4 @@
+from functools import reduce
 from pyanalib.pandas_helpers import *
 from .branches import *
 from .util import *
@@ -702,3 +703,40 @@ def make_spine_part_df(f):
 
     rename_to_XYZ(spine_part_df, cols_to_rename)
     return spine_part_df
+
+def make_spine_flash_df(f):
+    """
+    SPINE dataframe maker which containes flash branches from true and reco SPINE interactions.
+
+    :param f: file handle to the input ROOT file
+    :type f: uproot4.open file handle
+
+    :return: SPINE flashes dataframe
+    :rtype: pd.DataFrame   
+    """
+
+    rec_tree = f["recTree"]
+
+    # Load SPINE flash branches for reco interactions.
+    spineint_flashids_df        = loadbranches(rec_tree, spineint_flashids_branches)
+    spineint_flashscores_df     = loadbranches(rec_tree, spineint_flashscores_branches)
+    spineint_flashtimes_df      = loadbranches(rec_tree, spineint_flashtimes_branches)
+    spineint_flashvolumeids_df  = loadbranches(rec_tree, spineint_flashvolumeids_branches)
+
+    # Load SPINE flash branches for true interactions.
+    spinetint_flashids_df       = loadbranches(rec_tree, spinetint_flashids_branches)
+    spinetint_flashscores_df    = loadbranches(rec_tree, spinetint_flashscores_branches)
+    spinetint_flashtimes_df     = loadbranches(rec_tree, spinetint_flashtimes_branches)
+    spinetint_flashvolumeids_df = loadbranches(rec_tree, spinetint_flashvolumeids_branches)
+
+    # Unify column index names across all flash dataframes.
+    dfs = [spineint_flashids_df, spineint_flashscores_df, spineint_flashtimes_df, spineint_flashvolumeids_df,
+        spinetint_flashids_df, spinetint_flashscores_df, spinetint_flashtimes_df, spinetint_flashvolumeids_df]
+    for df in dfs:
+        assert df.index.nlevels == 3, f"Unexpected index depth: {df.index.nlevels}"
+        df.index.names = ["entry", "rec.dlp..index", "rec.dlp.flash..index"]
+
+    # Join reco and true flash dataframes.
+    spine_flash_df = reduce(lambda l, r: l.join(r, how='outer'), dfs)
+
+    return spine_flash_df

--- a/makedf/makedf.py
+++ b/makedf/makedf.py
@@ -588,7 +588,7 @@ def make_all_spine_df(f, get_best_match=True, **trkArgs):
     spine_int_df = make_spine_int_df(f, get_best_match)
 
     # Load SPINE particles dataframe
-    spine_part_df = make_spine_part_df(f, **trkArgs)
+    spine_part_df = make_spine_part_df(f, get_best_match, **trkArgs)
     add_upper_level_to_df("particle", spine_part_df)
 
     # Merge both dataframes
@@ -598,7 +598,7 @@ def make_all_spine_df(f, get_best_match=True, **trkArgs):
 
 def make_spine_int_mcnu_df(f, get_best_match=True):
     """
-    SPINE dataframe maker which containes all SPINE reco and true variables 
+    SPINE dataframe maker which containes all SPINE reco and true interaction variables 
     matched with MC nu dataframe.
     
     :param f: file handle to the input ROOT file
@@ -619,79 +619,54 @@ def make_spine_int_mcnu_df(f, get_best_match=True):
         rhs=mcnu_df,
         left_on=["entry", ("rec", "dlp_true", "mct_index", "")],
         right_index=True,
-        how="left")
+        how="left",
+        validate="many_to_one"
+    )
 
     return spineint_mcnu_df
 
-
-def make_spine_part_df(f):
-    # Load SPINE reco particle (rec.dlp.particle.) branches
-    spine_part_df = loadbranches(f["recTree"], spinepart_branches)
-    spine_part_df = spine_part_df.rec.dlp.particles
-
-    # Load SPINE true particle (rec.dlp_true.particle.) branches
-    spine_true_part_df = loadbranches(f["recTree"], spinetpart_branches)
-    spine_true_part_df = spine_true_part_df.rec.dlp_true.particles
-    spine_true_part_df_prefix = "strue" # SPINE true
-    add_upper_level_to_df(spine_true_part_df_prefix, spine_true_part_df)
-    spine_true_part_df.columns = [s for s in spine_true_part_df.columns]
-
-    # Load true particle branches
-    true_part_df = loadbranches(f["recTree"], trueparticlebranches)
-    true_part_df = true_part_df.rec.true_particles
-    true_part_df_prefix = "true"
-    add_upper_level_to_df(true_part_df_prefix, true_part_df)
-
-    # ============ Do matching between SPINE true particles and reco ID matched ============ #
-    # - Load match_ids and overlaps branches
-    spine_part_match_df = loadbranches(f["recTree"], spinepart_matched_branches)
-    spine_part_match_overlap_df = loadbranches(f["recTree"], spinepart_matchovrlp_branches)
-    # - Dataframe with match ids and overlaps
-    spine_part_match_overlap_df.index.names = spine_part_match_df.index.names
-    spine_part_match_df = multicol_merge(spine_part_match_df, spine_part_match_overlap_df, left_index=True, right_index=True, how="left", validate="one_to_one")
-    spine_part_match_df = spine_part_match_df.rec.dlp.particles 
-    # - Get the best match (highest match_overlap), assume it's sorted
-    spine_bestmatch_df = spine_part_match_df.groupby(level=list(range(spine_part_match_df.index.nlevels-1))).first()
-    spine_bestmatch_df.columns = [s for s in spine_bestmatch_df.columns]
-    # - Match SPINE true particles with their pair (match id - overlap)
-    spine_bestmatch_wids_df = pd.merge(spine_bestmatch_df, spine_true_part_df, 
-                                       left_on=["entry", "match_ids"], 
-                                       right_on=["entry", (spine_true_part_df_prefix, "id", "")], 
-                                       how="left")
-    spine_bestmatch_wids_df.index = spine_bestmatch_df.index
+def make_spine_part_mcpart_df(f, get_best_match=True):
+    """
+    SPINE dataframe maker which containes all SPINE reco and true particle variables 
+    matched with MC part dataframe.
     
-    # ============ Match SPINE true particles dataframe with true particles dataframe ============ #
-    bestmatch_true_particles_df = multicol_merge(spine_bestmatch_wids_df, true_part_df, 
-                                                 left_on=["entry", (spine_true_part_df_prefix, "track_id", "")], 
-                                                 right_on=["entry", (true_part_df_prefix, "G4ID", "")],
-                                                 how="left")
-    bestmatch_true_particles_df.index = spine_bestmatch_wids_df.index
+    :param f: file handle to the input ROOT file
+    :type f: uproot4.open file handle
 
-    # Fill column levels
-    max_num_levels = max(bestmatch_true_particles_df.columns.nlevels, spine_part_df.columns.nlevels)
-    spine_part_df.columns = pd.MultiIndex.from_tuples(
-        [tuple(list(c) + [""] * (max_num_levels - len(c))) for c in spine_part_df.columns]
-    ) 
+    :return: SPINE + MC particles dataframe
+    :rtype: pd.DataFrame   
+    """
 
-    # Add true information to SPINE reco particle dataframe
-    for c in bestmatch_true_particles_df.columns:
-        spine_part_df[c] = bestmatch_true_particles_df[c]
+    # Load SPINE particles dataframe.
+    spinepart_df = make_spine_part_df(f, get_best_match)
 
-    cols_to_rename = ["momentum", "end_point", "start_point", "start_dir", "end_dir", "vertex"] 
+    # Load MC (Geant4) particles branches.
+    mcpart_df = loadbranches(f["recTree"], trueparticlebranches)
 
-    rename_to_XYZ(spine_part_df, cols_to_rename)
-    return spine_part_df
+    # Match SPINE particles dataframe with MC (Geant4) particles dataframe.
+
+    spinepart_mcpart_df = multicol_merge(
+        lhs=spinepart_df.reset_index(level=[1, 2]),
+        rhs=mcpart_df.reset_index(level=[1]),
+        left_on=["entry", ("rec", "dlp_true", "particles", "track_id", "")],
+        right_on=["entry", ("rec", "true_particles", "G4ID", "", "", "")],
+        how="left",
+        validate="many_to_one"
+    ).set_index(["rec.dlp..index", "rec.dlp.particles..index"], append=True)
+
+    return spinepart_mcpart_df
 
 def make_spine_int_df(f, get_best_match=True):
     """
-    SPINE dataframe maker which containes all SPINE reco and true variables matched with MC nu dataframe.
+    SPINE dataframe maker which containes all SPINE reco and true interaction variables
+    matched with MC nu dataframe.
     
     :param f: file handle to the input ROOT file
     :type f: uproot4.open file handle
     :param get_best_match: `True` if a best match selection is needed.
     :type get_best_match: bool
 
-    :return: SPINE events dataframe
+    :return: SPINE interactions dataframe
     :rtype: pd.DataFrame   
     """
     # Get reco tree from file.
@@ -753,6 +728,73 @@ def make_spine_int_df(f, get_best_match=True):
     rename_to_XYZ(spineint_matched_with_true_df, cols_to_rename)
 
     return spineint_matched_with_true_df
+
+def make_spine_part_df(f, get_best_match=True):
+    """
+    SPINE dataframe maker which containes all SPINE reco and true particle variables 
+    matched with MC nu dataframe.
+    
+    :param f: file handle to the input ROOT file
+    :type f: uproot4.open file handle
+    :param get_best_match: `True` if a best match selection is needed.
+    :type get_best_match: bool
+
+    :return: SPINE particles dataframe
+    :rtype: pd.DataFrame   
+    """
+    rec_tree = f["recTree"]
+
+    spinepart_df                = loadbranches(rec_tree, spinepart_branches)
+    spinetpart_df               = loadbranches(rec_tree, spinetpart_branches)
+    spinepart_matchids_df       = loadbranches(rec_tree, spinepart_matched_branches)
+    spinepart_matchovrlp_df     = loadbranches(rec_tree, spinepart_matchovrlp_branches)
+
+    # Match match_ids and match_overlaps data.
+    spinepart_matches_df = spinepart_matchids_df.merge(
+        spinepart_matchovrlp_df,
+        left_on = ["entry", "rec.dlp..index", "rec.dlp.particles..index", "rec.dlp.particles.match_ids..index"],
+        right_on = ["entry", "rec.dlp..index", "rec.dlp.particles..index", "rec.dlp.particles.match_overlaps..index"],
+        how="left",
+        validate="one_to_one"
+    )
+
+    matches_df = spinepart_matches_df
+    validate_matched = "many_to_one"
+    validate_matched_with_true = "many_to_many"
+    if get_best_match:
+        # Get best interaction matching
+        spinepart_best_matches_df = (
+            spinepart_matches_df
+            .sort_values(("rec", "dlp", "particles", "match_overlaps"), ascending=False)
+            .groupby(level=["entry", "rec.dlp..index", "rec.dlp.particles..index"])
+            .first()
+        )
+        matches_df = spinepart_best_matches_df
+        validate_matched = "one_to_one"
+        validate_matched_with_true = "many_to_one"
+
+    # Match reco SPINE particles to match_ids and match_overlaps data.
+    spinepart_matched_df = multicol_merge(
+        lhs=matches_df,
+        rhs=spinepart_df,
+        on=["entry", "rec.dlp..index", "rec.dlp.particles..index"],
+        how="left",
+        validate=validate_matched
+    )
+
+    spinepart_matched_with_true_df = multicol_merge(
+        lhs=spinepart_matched_df.reset_index(level=[1, 2]),
+        rhs=spinetpart_df.reset_index(level=[1, 2]),
+        left_on=["entry", ("rec", "dlp", "particles", "match_ids")],
+        right_on=["entry", ("rec", "dlp_true", "particles", "id")],
+        how="left",
+        validate=validate_matched_with_true
+    ).set_index(["rec.dlp..index", "rec.dlp.particles..index"], append=True)
+
+    cols_to_rename = ["momentum", "end_point", "start_point", "start_dir", "end_dir", "vertex"] 
+    rename_to_XYZ(spinepart_matched_with_true_df, cols_to_rename)
+
+    return spinepart_matched_with_true_df
 
 def make_spine_flash_df(f):
     """

--- a/makedf/makedf.py
+++ b/makedf/makedf.py
@@ -485,26 +485,6 @@ def make_pandora_df(f, trkScoreCut=False, trkDistCut=50., cutClearCosmic=False, 
     #print(slcdf.pfp.trk.chi2pid.head(50))
     return slcdf
 
-def make_spine_df(f, trkDistCut=-1, requireFiducial=True, **trkArgs):
-    # load
-    partdf = make_spinepartdf(f, **trkArgs)
-    partdf.columns = pd.MultiIndex.from_tuples([tuple(["particle"] + list(c)) for c in partdf.columns])
-    eslcdf = make_spineslcdf(f)
-
-    # merge in tracks
-    eslcdf = multicol_merge(eslcdf, partdf, left_index=True, right_index=True, how="right", validate="one_to_many")
-
-    #print(*eslcdf.columns, sep="\n")
-    eslcdf = multicol_add(eslcdf, dmagdf(eslcdf.vertex, eslcdf.particle.start_point).rename("dist_to_vertex"))
-
-    if trkDistCut > 0:
-        eslcdf = eslcdf[eslcdf.dist_to_vertex < trkDistCut]
-    # require fiducial verex
-    if requireFiducial:
-        eslcdf = eslcdf[InFV(eslcdf.vertex, 50)]
-
-    return eslcdf
-
 def make_stubs(f, det="ICARUS"):
     stubdf = loadbranches(f["recTree"], stubbranches)
     stubdf = stubdf.rec.slc.reco.stub
@@ -602,6 +582,26 @@ def make_stubs(f, det="ICARUS"):
 
     #return pd.concat(df_tosave, axis=1)
 
+def make_spine_df(f, trkDistCut=-1, requireFiducial=True, **trkArgs):
+    # load
+    partdf = make_spinepartdf(f, **trkArgs)
+    partdf.columns = pd.MultiIndex.from_tuples([tuple(["particle"] + list(c)) for c in partdf.columns])
+    eslcdf = make_spineslcdf(f)
+
+    # merge in tracks
+    eslcdf = multicol_merge(eslcdf, partdf, left_index=True, right_index=True, how="right", validate="one_to_many")
+
+    #print(*eslcdf.columns, sep="\n")
+    eslcdf = multicol_add(eslcdf, dmagdf(eslcdf.vertex, eslcdf.particle.start_point).rename("dist_to_vertex"))
+
+    if trkDistCut > 0:
+        eslcdf = eslcdf[eslcdf.dist_to_vertex < trkDistCut]
+    # require fiducial verex
+    if requireFiducial:
+        eslcdf = eslcdf[InFV(eslcdf.vertex, 50)]
+
+    return eslcdf
+
 def make_spineslcdf(f):
     eslcdf = loadbranches(f["recTree"], eslcbranches)
     eslcdf = eslcdf.rec.dlp
@@ -625,7 +625,6 @@ def make_spineslcdf(f):
     eslc_matchdf = eslc_matchdf.rec.dlp
 
     # Then use bestmatch.match to get the nu ids in etintdf
-    #eslc_matchdf_wids = pd.merge(eslc_matchdf, etintdf, left_on=["entry", "match"], right_on=["entry", "id"], how="left")
     eslc_matchdf_wids = pd.merge(eslc_matchdf, etintdf, left_on=["entry", "match_ids"], right_on=["entry", "id"], how="left")
     eslc_matchdf_wids.index = eslc_matchdf.index
 
@@ -634,7 +633,6 @@ def make_spineslcdf(f):
     eslc_matchdf_trueints.index = eslc_matchdf_wids.index
 
     # delete unnecesary matching branches
-    #del eslc_matchdf_trueints[("match", "")]
     del eslc_matchdf_trueints[("match_ids", "")]
     del eslc_matchdf_trueints[("nu_id", "")]
     del eslc_matchdf_trueints[("id", "")]
@@ -690,30 +688,25 @@ def make_spinepartdf(f):
     bestmatch.columns = [s for s in bestmatch.columns]
 
     # Then use betmatch.match to get the G4 track IDs in etpartdf
-    #bestmatch_wids = pd.merge(bestmatch, etpartdf, left_on=["entry", "match"], right_on=["entry", "id"], how="left")
     bestmatch_wids = pd.merge(bestmatch, etpartdf, left_on=["entry", "match_ids"], right_on=["entry", ("id", "")], how="left")
     bestmatch_wids.index = bestmatch.index
 
     # Now use the G4 track IDs to get the true particle information
-    #bestmatch_trueparticles = multicol_merge(bestmatch_wids, tpartdf, left_on=["entry", "track_id"], right_on=["entry", ("G4ID", "")], how="left")
     bestmatch_trueparticles = multicol_merge(bestmatch_wids, tpartdf, left_on=["entry", ("track_id", "")], right_on=["entry", ("G4ID", "")], how="left")
     bestmatch_trueparticles.index = bestmatch_wids.index
 
     # delete unnecesary matching branches
-    #del bestmatch_trueparticles[("match", "")]
     del bestmatch_trueparticles[("match_ids", "")]
     del bestmatch_trueparticles[("track_id", "")]
     del bestmatch_trueparticles[("id", "")]
 
     # add extra level to epartdf columns
-    #epartdf.columns = pd.MultiIndex.from_tuples([tuple(list(c) + [""]) for c in epartdf.columns])
     epartdf.columns = pd.MultiIndex.from_tuples(
         [tuple(list(c) + [""] * (5 - len(c))) for c in epartdf.columns]
     ) 
 
     # put everything in epartdf
     for c in bestmatch_trueparticles.columns:
-    #    epartdf[tuple(["truth"] + list(c))] = bestmatch_trueparticles[c]
         tuple_key = ("truth",) + c
         epartdf[tuple_key] = bestmatch_trueparticles[c]
     # Fix position names (I0, I1, I2) -> (x, y, z)
@@ -723,7 +716,6 @@ def make_spinepartdf(f):
         if s == "I2": return "z"
         return s
     def fixpos(c):
-        #if c[0] not in ["end_point", "start_point", "start_dir", "vertex"]: return c
         rename = False
         new_tuple = c
         sub_columns = ["momentum", "end_point", "start_point", "start_dir", "end_dir", "vertex"]

--- a/makedf/makedf.py
+++ b/makedf/makedf.py
@@ -606,45 +606,53 @@ def make_spine_df(f, trkDistCut=-1, requireFiducial=True, **trkArgs):
     return spine_df
 
 def make_spine_int_df(f):
-    eslcdf = loadbranches(f["recTree"], spineint_branches)
-
-    etintdf = loadbranches(f["recTree"], spinetint_branches)
+    """
+    SPINE dataframe maker which containes all SPINE reco and true variables matched with MC nu dataframe.
     
-    # match to the truth info
-    mcdf = make_mcdf(f)
-    # mc is truth
-    mcdf.columns = pd.MultiIndex.from_tuples([tuple(["truth"] + list(c)) for c in mcdf.columns])
+    :param f: file handle to the input ROOT file
+    :type f: uproot4.open file handle
 
-    # Do matching
-    # 
-    # First get the ML true particle IDs matched to each reco particle
-    eslc_matchdf = loadbranches(f["recTree"], spineint_matched_branches)
-    eslc_match_overlap_df = loadbranches(f["recTree"], spineint_matchovrlp_branches)
-    eslc_match_overlap_df.index.names = eslc_matchdf.index.names
+    :return: SPINE events dataframe
+    :rtype: pd.DataFrame   
+    """
 
-    eslc_matchdf = multicol_merge(eslc_matchdf, eslc_match_overlap_df, left_index=True, right_index=True, how="left", validate="one_to_one")
-    eslc_matchdf = eslc_matchdf.rec.dlp
+    # Get reco tree from file.
+    rec_tree = f["recTree"]
 
-    # Then use bestmatch.match to get the nu ids in etintdf
-    eslc_matchdf_wids = multicol_merge(eslc_matchdf, etintdf, left_on=["entry", "match_ids"], right_on=["entry",  ("rec", "dlp_true", "id", "")], how="left")
-    eslc_matchdf_wids.index = eslc_matchdf.index
+    # Load SPINE interaction and matches branches.
+    spinetint_df            = loadbranches(rec_tree, spinetint_branches)
+    spineint_df             = loadbranches(rec_tree, spineint_branches)
+    spineint_matchids_df    = loadbranches(rec_tree, spineint_matched_branches)
+    spineint_matchovrlp_df  = loadbranches(rec_tree, spineint_matchovrlp_branches)
 
-    # Now use nu_ids to get the true interaction information
-    eslc_matchdf_trueints = multicol_merge(eslc_matchdf_wids, mcdf, left_on=["entry", ("rec", "dlp_true", "nu_id")], right_index=True, how="left")
-    eslc_matchdf_trueints.index = eslc_matchdf_wids.index
+    # Load the MC dataframe.
+    mcnu_df = make_mcdf(f)
 
-    # first match is best match
-    bestmatch = eslc_matchdf_trueints.groupby(level=list(range(eslc_matchdf_trueints.index.nlevels-1))).first()
+    # Match match_ids and match_overlaps data.
+    spineint_matches_df = spineint_matchids_df.merge(spineint_matchovrlp_df, left_on=["entry", "rec.dlp..index", "rec.dlp.match_ids..index"], right_on=["entry", "rec.dlp..index", "rec.dlp.match_overlaps..index"], how="left")
 
-    # add extra levels to eslcdf columns
-    eslcdf.columns = pd.MultiIndex.from_tuples([tuple(list(c) + [""]*2) for c in eslcdf.columns])
+    # Match reco SPINE interactions to match_ids and match_overlaps data.
+    spineint_matched_df = multicol_merge( lhs=spineint_matches_df, rhs=spineint_df, on=["entry", "rec.dlp..index"], how="left", validate="one_to_one")
 
-    eslcdf_withmc = multicol_merge(eslcdf, bestmatch, left_index=True, right_index=True, how="left")
+    # Match reco SPINE interactions to true SPINE interactions using match_ids and match_overlaps data.
+    spineint_matched_with_true_df = multicol_merge(spineint_matched_df, spinetint_df, 
+                                                    left_on=["entry", ("rec", "dlp", "match_ids", "")], right_on=["entry", ("rec", "dlp_true", "id", "")],
+                                                    how="left", validate="many_to_one")
+    spineint_matched_with_true_df.index = spineint_matched_df.index
 
-    cols_to_rename = ["momentum", "end_point", "start_point", "start_dir", "end_dir", "reco_vertex", "vertex"]
-    rename_to_XYZ(eslcdf_withmc, cols_to_rename)
+    # Match reco and true SPINE interactions with MC interactions data.
+    add_upper_level_to_df("mcnu", mcnu_df)
+    spineint_matched_with_true_mcnu_df = multicol_merge(spineint_matched_with_true_df, mcnu_df, left_on=["entry", ("rec", "dlp_true", "nu_id", "")], right_index=True, how="left")
 
-    return eslcdf_withmc
+    # Get best interaction matching
+    bestmatch_indices = spineint_matched_with_true_mcnu_df[("rec", "dlp", "match_overlaps", "")].groupby(level="entry").idxmax(skipna=False)
+    spine_bestmatch_df = spineint_matched_with_true_mcnu_df.loc[bestmatch_indices]
+
+    # Rename I0-I1-I2 variables to x-y-z
+    rename_to_XYZ(spine_bestmatch_df, ["momentum", "end_point", "start_point", "start_dir", "end_dir", "reco_vertex", "vertex"])
+
+    return spine_bestmatch_df
+
 
 def make_spine_part_df(f):
     # Load SPINE reco particle (rec.dlp.particle.) branches

--- a/makedf/makedf.py
+++ b/makedf/makedf.py
@@ -662,52 +662,122 @@ def make_spineslcdf(f):
     return eslcdf_withmc
 
 def make_spinepartdf(f):
+    #print("SPINE REC PARTICLES eparticlebranches: ")
+    #print("\n".join(f" - {b}" for b in eparticlebranches))
     epartdf = loadbranches(f["recTree"], eparticlebranches)
+    #print("epartdf BEFORE epartdf.rec.dlp.particles:")
+    #print("\n".join(f" - {c}" for c in epartdf.columns))
     epartdf = epartdf.rec.dlp.particles
+    print("epartdf AFTER epartdf.rec.dlp.particles:")
+    print("\n".join(f" - {c}" for c in epartdf.columns))
+    print("SHAPE: ", epartdf.shape)
 
+    #print("TRUE PARTICLES trueparticlebranches: ")
+    #print("\n".join(f" - {b}" for b in trueparticlebranches))
     tpartdf = loadbranches(f["recTree"], trueparticlebranches)
+    #print("tpartdf BEFORE tpartdf.rec.true_particles")
+    #print("\n".join(f" - {c}" for c in tpartdf.columns))
     tpartdf = tpartdf.rec.true_particles
+    print("tpartdf AFRER tpartdf.rec.true_particles")
+    print("\n".join(f" - {c}" for c in tpartdf.columns))
+    print("SHAPE: ", tpartdf.shape)
     # cut out EMShowerDaughters
     # tpartdf = tpartdf[(tpartdf.parent == 0)]
 
+    #print("SPINE TRUE PARTICLES etrueparticlebranches: ")
+    #print("\n".join(f" - {b}" for b in etrueparticlebranches))
     etpartdf = loadbranches(f["recTree"], etrueparticlebranches)
+    #print("etpartdf BEFORE etpartdf.rec.dlp_true.particles")
+    #print("\n".join(f" - {c}" for c in etpartdf.columns))
     etpartdf = etpartdf.rec.dlp_true.particles
-    etpartdf.columns = [s for s in etpartdf.columns] # ???
-    
+    #print("etpartdf AFTER etpartdf.rec.dlp_true.particles")
+    #print("\n".join(f" - {c}" for c in etpartdf.columns))
+    etpartdf.columns = [s for s in etpartdf.columns]
+    print("etpartdf AFTER etpartdf.columns = [s for s in etpartdf.columns]")
+    print("\n".join(f" - {c}" for c in etpartdf.columns))
+    print("SHAPE: ", etpartdf.shape)
      
     # Do matching
     # 
     # First get the ML true particle IDs matched to each reco particle
     epart_matchdf = loadbranches(f["recTree"], eparticlematchedbranches)
-    """
     epart_match_overlap_df = loadbranches(f["recTree"], eparticlematchovrlpbranches)
     epart_match_overlap_df.index.names = epart_matchdf.index.names
+    #print("\nepart_matchdf index names:", epart_matchdf.index.names)
+    #print("epart_match_overlap_df index names:", epart_match_overlap_df.index.names)
+    #print(epart_matchdf.head(10))
+    #print(epart_match_overlap_df.head(10))
+
     epart_matchdf = multicol_merge(epart_matchdf, epart_match_overlap_df, left_index=True, right_index=True, how="left", validate="one_to_one")
+
+    #print("\nepart_matchdf AFTER MERGING")
+    #print(epart_matchdf.head(10))
+    #print("\n".join(f" - {c}" for c in epart_matchdf.columns))
     epart_matchdf = epart_matchdf.rec.dlp.particles
     # get the best match (highest match_overlap), assume it's sorted
+
+    #print("epartdf before group by")
+    #print("\n".join(f" - {c}" for c in epart_matchdf.columns))
+    #print(epart_matchdf.head(10))
     bestmatch = epart_matchdf.groupby(level=list(range(epart_matchdf.index.nlevels-1))).first()
+
+    #print("bestmatch after groupby")
+    #print("\n".join(f" - {c}" for c in bestmatch.columns))
+    #print(bestmatch.head(10))
+    #print(bestmatch.shape)
     bestmatch.columns = [s for s in bestmatch.columns]
+    #print(bestmatch.shape)
 
     # Then use betmatch.match to get the G4 track IDs in etpartdf
-    bestmatch_wids = pd.merge(bestmatch, etpartdf, left_on=["entry", "match"], right_on=["entry", "id"], how="left")
+    #bestmatch_wids = pd.merge(bestmatch, etpartdf, left_on=["entry", "match"], right_on=["entry", "id"], how="left")
+    bestmatch_wids = pd.merge(bestmatch, etpartdf, left_on=["entry", "match_ids"], right_on=["entry", ("id", "")], how="left")
+    #print("bestmatch_wids after merging")
+    #print("\n".join(f" - {c}" for c in bestmatch_wids.columns))
+    #print(bestmatch_wids.T.head(10))
+    #print(bestmatch_wids.head(10))
+    #print(bestmatch_wids.shape)
     bestmatch_wids.index = bestmatch.index
 
     # Now use the G4 track IDs to get the true particle information
-    bestmatch_trueparticles = multicol_merge(bestmatch_wids, tpartdf, left_on=["entry", "track_id"], right_on=["entry", ("G4ID", "")], how="left")
+    #print("Columnas tpartdf:", tpartdf.columns.tolist())
+    #print("tpartdf shape: ", tpartdf.shape)
+    #bestmatch_trueparticles = multicol_merge(bestmatch_wids, tpartdf, left_on=["entry", "track_id"], right_on=["entry", ("G4ID", "")], how="left")
+    bestmatch_trueparticles = multicol_merge(bestmatch_wids, tpartdf, left_on=["entry", ("track_id", "")], right_on=["entry", ("G4ID", "")], how="left")
     bestmatch_trueparticles.index = bestmatch_wids.index
 
     # delete unnecesary matching branches
-    del bestmatch_trueparticles[("match", "")]
+    #del bestmatch_trueparticles[("match", "")]
+    del bestmatch_trueparticles[("match_ids", "")]
     del bestmatch_trueparticles[("track_id", "")]
     del bestmatch_trueparticles[("id", "")]
 
     # add extra level to epartdf columns
-    epartdf.columns = pd.MultiIndex.from_tuples([tuple(list(c) + [""]) for c in epartdf.columns])
+    print("ADD EXTRA LEVEL TO EPARTDF")
+    print("\n".join(f" - {c}" for c in epartdf.columns))
+    print(epartdf.head(10))
+    print(epartdf.shape)
+    #epartdf.columns = pd.MultiIndex.from_tuples([tuple(list(c) + [""]) for c in epartdf.columns])
+    epartdf.columns = pd.MultiIndex.from_tuples(
+        [tuple(list(c) + [""] * (5 - len(c))) for c in epartdf.columns]
+    ) 
+    print("AFTER ADD EXTRA LEVEL")
+    print("\n".join(f" - {c}" for c in epartdf.columns))
+    print(epartdf.head(10))
+    print(epartdf.shape)
 
     # put everything in epartdf
+    print("BESTMATCH_TRUEPARTICLES DF")
+    print("\n".join(f" - {c}" for c in bestmatch_trueparticles.columns))
+    print(bestmatch_trueparticles.head(10))
+    print(bestmatch_trueparticles.shape)
     for c in bestmatch_trueparticles.columns:
-        epartdf[tuple(["truth"] + list(c))] = bestmatch_trueparticles[c]
-
+    #    epartdf[tuple(["truth"] + list(c))] = bestmatch_trueparticles[c]
+        tuple_key = ("truth",) + c
+        epartdf[tuple_key] = bestmatch_trueparticles[c]
+    print("FINAL DF")
+    print("\n".join(f" - {c}" for c in epartdf.columns))
+    print(epartdf.head(10))
+    print(epartdf.shape)
     # Fix position names (I0, I1, I2) -> (x, y, z)
     def mappos(s):
         if s == "I0": return "x"
@@ -715,9 +785,24 @@ def make_spinepartdf(f):
         if s == "I2": return "z"
         return s
     def fixpos(c):
-        if c[0] not in ["end_point", "start_point", "start_dir", "vertex"]: return c
-        return tuple([c[0]] + [mappos(c[1])] + list(c[2:]))
+        #if c[0] not in ["end_point", "start_point", "start_dir", "vertex"]: return c
+        rename = False
+        new_tuple = c
+        sub_columns = ["momentum", "end_point", "start_point", "start_dir", "end_dir", "vertex"]
+        if c[0] == "truth":
+            if c[1] in sub_columns:
+                new_tuple = tuple([c[0]] + [c[1]] + [mappos(c[2])] + list(c[3:]))
+        else:
+            if c[0] in sub_columns:
+                new_tuple = tuple([c[0]] + [mappos(c[1])] + list(c[2:]))
+        return new_tuple
+
 
     epartdf.columns = pd.MultiIndex.from_tuples([fixpos(c) for c in epartdf.columns])
-    """
+
+    print("FINAL DF AFTER RENAMING")
+    print("\n".join(f" - {c}" for c in epartdf.columns))
+    print(epartdf.head(10))
+    print(epartdf.shape)
+
     return epartdf

--- a/makedf/makedf.py
+++ b/makedf/makedf.py
@@ -583,26 +583,28 @@ def make_stubs(f, det="ICARUS"):
     #return pd.concat(df_tosave, axis=1)
 
 def make_spine_df(f, trkDistCut=-1, requireFiducial=True, **trkArgs):
-    # load
-    partdf = make_spinepartdf(f, **trkArgs)
-    partdf.columns = pd.MultiIndex.from_tuples([tuple(["particle"] + list(c)) for c in partdf.columns])
-    eslcdf = make_spineslcdf(f)
+    # Load SPINE interactions dataframe
+    spine_int_df = make_spine_int_df(f)
 
-    # merge in tracks
-    eslcdf = multicol_merge(eslcdf, partdf, left_index=True, right_index=True, how="right", validate="one_to_many")
+    # Load SPINE particles dataframe
+    spine_part_df = make_spine_part_df(f, **trkArgs)
+    spine_part_df.columns = pd.MultiIndex.from_tuples([tuple(["particle"] + list(c)) for c in spine_part_df.columns])
 
-    #print(*eslcdf.columns, sep="\n")
-    eslcdf = multicol_add(eslcdf, dmagdf(eslcdf.vertex, eslcdf.particle.start_point).rename("dist_to_vertex"))
+    # Merge both dataframes
+    spine_df = multicol_merge(spine_int_df, spine_part_df, left_index=True, right_index=True, how="right", validate="one_to_many")
 
+    # Add distance-to-vertex particle column to SPINE dataframe
+    spine_df = multicol_add(spine_df, dmagdf(spine_df.vertex, spine_df.particle.start_point).rename("dist_to_vertex"))
+
+    # Check and apply cuts
     if trkDistCut > 0:
-        eslcdf = eslcdf[eslcdf.dist_to_vertex < trkDistCut]
-    # require fiducial verex
+        spine_df = spine_df[spine_df.dist_to_vertex < trkDistCut]
     if requireFiducial:
-        eslcdf = eslcdf[InFV(eslcdf.vertex, 50)]
+        spine_df = spine_df[InFV(spine_df.vertex, 50)]
 
-    return eslcdf
+    return spine_df
 
-def make_spineslcdf(f):
+def make_spine_int_df(f):
     eslcdf = loadbranches(f["recTree"], spineintbranches)
     eslcdf = eslcdf.rec.dlp
 
@@ -632,11 +634,6 @@ def make_spineslcdf(f):
     eslc_matchdf_trueints = multicol_merge(eslc_matchdf_wids, mcdf, left_on=["entry", "nu_id"], right_index=True, how="left")
     eslc_matchdf_trueints.index = eslc_matchdf_wids.index
 
-    # delete unnecesary matching branches
-    del eslc_matchdf_trueints[("match_ids", "")]
-    del eslc_matchdf_trueints[("nu_id", "")]
-    del eslc_matchdf_trueints[("id", "")]
-
     # first match is best match
     bestmatch = eslc_matchdf_trueints.groupby(level=list(range(eslc_matchdf_trueints.index.nlevels-1))).first()
 
@@ -659,56 +656,79 @@ def make_spineslcdf(f):
 
     return eslcdf_withmc
 
-def make_spinepartdf(f):
-    epartdf = loadbranches(f["recTree"], spinepartbranches)
-    epartdf = epartdf.rec.dlp.particles
+def make_spine_part_df(f):
+    # Load SPINE reco particle (rec.dlp.particle.) branches
+    spine_part_df = loadbranches(f["recTree"], spinepartbranches)
+    spine_part_df = spine_part_df.rec.dlp.particles
+    #print("\nSPINE_PART_DF")
+    #print("\n".join(str(col) for col in spine_part_df.columns))
 
-    tpartdf = loadbranches(f["recTree"], trueparticlebranches)
-    tpartdf = tpartdf.rec.true_particles
-    # cut out EMShowerDaughters
-    # tpartdf = tpartdf[(tpartdf.parent == 0)]
+    # Load SPINE true particle (rec.dlp_true.particle.) branches
+    spine_true_part_df = loadbranches(f["recTree"], spinetpartbranches)
+    spine_true_part_df = spine_true_part_df.rec.dlp_true.particles
+    spine_true_part_df_prefix = "strue" # SPINE true
+    add_upper_level_to_df(spine_true_part_df_prefix, spine_true_part_df)
+    #spine_true_part_df.columns = pd.MultiIndex.from_tuples(
+    #    [(spine_true_part_df_prefix,) + col for col in spine_true_part_df.columns]
+    #)
+    spine_true_part_df.columns = [s for s in spine_true_part_df.columns]
+    #print("\nSPINE_TRUE_PART_DF")
+    #print("\n".join(str(col) for col in spine_true_part_df.columns))
 
-    etpartdf = loadbranches(f["recTree"], spinetpartbranches)
-    etpartdf = etpartdf.rec.dlp_true.particles
-    etpartdf.columns = [s for s in etpartdf.columns]
-     
-    # Do matching
-    # 
-    # First get the ML true particle IDs matched to each reco particle
-    epart_matchdf = loadbranches(f["recTree"], spinepartmatchedbranches)
-    epart_match_overlap_df = loadbranches(f["recTree"], spinepartmatchovrlpbranches)
-    epart_match_overlap_df.index.names = epart_matchdf.index.names
+    # Load true particle branches
+    true_part_df = loadbranches(f["recTree"], trueparticlebranches)
+    true_part_df = true_part_df.rec.true_particles
+    true_part_df_prefix = "true"
+    add_upper_level_to_df(true_part_df_prefix, true_part_df)
+    #true_part_df.columns = pd.MultiIndex.from_tuples(
+    #    [(true_part_df_prefix,) + col for col in true_part_df.columns]
+    #)
+    #print("\nTRUE_PART_DF")
+    #print("\n".join(str(col) for col in true_part_df))
 
-    epart_matchdf = multicol_merge(epart_matchdf, epart_match_overlap_df, left_index=True, right_index=True, how="left", validate="one_to_one")
+    # ============ Do matching between SPINE true particles and reco ID matched ============ #
+    # - Load match_ids and overlaps branches
+    spine_part_match_df = loadbranches(f["recTree"], spinepartmatchedbranches)
+    spine_part_match_overlap_df = loadbranches(f["recTree"], spinepartmatchovrlpbranches)
+    # - Dataframe with match ids and overlaps
+    spine_part_match_overlap_df.index.names = spine_part_match_df.index.names
+    spine_part_match_df = multicol_merge(spine_part_match_df, spine_part_match_overlap_df, left_index=True, right_index=True, how="left", validate="one_to_one")
+    spine_part_match_df = spine_part_match_df.rec.dlp.particles 
+    # - Get the best match (highest match_overlap), assume it's sorted
+    spine_bestmatch_df = spine_part_match_df.groupby(level=list(range(spine_part_match_df.index.nlevels-1))).first()
+    spine_bestmatch_df.columns = [s for s in spine_bestmatch_df.columns]
+    #print("\nSPINE_BESTMATCH_DF")
+    #print("\n".join(str(col) for col in spine_bestmatch_df.columns))
+    # - Match SPINE true particles with their pair (match id - overlap)
+    spine_bestmatch_wids_df = pd.merge(spine_bestmatch_df, spine_true_part_df, 
+                                       left_on=["entry", "match_ids"], 
+                                       right_on=["entry", (spine_true_part_df_prefix, "id", "")], 
+                                       how="left")
+    spine_bestmatch_wids_df.index = spine_bestmatch_df.index
+    #print("\nSPINE_BESTMATCH_WIDS_DF")
+    #print("\n".join(str(col) for col in spine_bestmatch_wids_df.columns))
+    
+    # ============ Match SPINE true particles dataframe with true particles dataframe ============ #
+    bestmatch_true_particles_df = multicol_merge(spine_bestmatch_wids_df, true_part_df, 
+                                                 left_on=["entry", (spine_true_part_df_prefix, "track_id", "")], 
+                                                 right_on=["entry", (true_part_df_prefix, "G4ID", "")],
+                                                 how="left")
+    bestmatch_true_particles_df.index = spine_bestmatch_wids_df.index
+    #print("\nBESTMATCH_TRUE_PARTICLES_DF")
+    #print("\n".join(str(col) for col in bestmatch_true_particles_df.columns))
 
-    epart_matchdf = epart_matchdf.rec.dlp.particles
-    # get the best match (highest match_overlap), assume it's sorted
-
-    bestmatch = epart_matchdf.groupby(level=list(range(epart_matchdf.index.nlevels-1))).first()
-    bestmatch.columns = [s for s in bestmatch.columns]
-
-    # Then use betmatch.match to get the G4 track IDs in etpartdf
-    bestmatch_wids = pd.merge(bestmatch, etpartdf, left_on=["entry", "match_ids"], right_on=["entry", ("id", "")], how="left")
-    bestmatch_wids.index = bestmatch.index
-
-    # Now use the G4 track IDs to get the true particle information
-    bestmatch_trueparticles = multicol_merge(bestmatch_wids, tpartdf, left_on=["entry", ("track_id", "")], right_on=["entry", ("G4ID", "")], how="left")
-    bestmatch_trueparticles.index = bestmatch_wids.index
-
-    # delete unnecesary matching branches
-    del bestmatch_trueparticles[("match_ids", "")]
-    del bestmatch_trueparticles[("track_id", "")]
-    del bestmatch_trueparticles[("id", "")]
-
-    # add extra level to epartdf columns
-    epartdf.columns = pd.MultiIndex.from_tuples(
-        [tuple(list(c) + [""] * (5 - len(c))) for c in epartdf.columns]
+    # Fill column levels
+    max_num_levels = max(bestmatch_true_particles_df.columns.nlevels, spine_part_df.columns.nlevels)
+    spine_part_df.columns = pd.MultiIndex.from_tuples(
+        [tuple(list(c) + [""] * (max_num_levels - len(c))) for c in spine_part_df.columns]
     ) 
+    #print("\nSPINE_PART_DF_AFTER_MERGING")
+    #print("\n".join(str(col) for col in bestmatch_true_particles_df.columns))
 
-    # put everything in epartdf
-    for c in bestmatch_trueparticles.columns:
-        tuple_key = ("truth",) + c
-        epartdf[tuple_key] = bestmatch_trueparticles[c]
+    # Add true information to SPINE reco particle dataframe
+    for c in bestmatch_true_particles_df.columns:
+        spine_part_df[c] = bestmatch_true_particles_df[c]
+
     # Fix position names (I0, I1, I2) -> (x, y, z)
     def mappos(s):
         if s == "I0": return "x"
@@ -716,10 +736,10 @@ def make_spinepartdf(f):
         if s == "I2": return "z"
         return s
     def fixpos(c):
-        rename = False
         new_tuple = c
         sub_columns = ["momentum", "end_point", "start_point", "start_dir", "end_dir", "vertex"]
-        if c[0] == "truth":
+        true_prefixes = [spine_true_part_df_prefix, true_part_df_prefix]
+        if c[0] in true_prefixes:
             if c[1] in sub_columns:
                 new_tuple = tuple([c[0]] + [c[1]] + [mappos(c[2])] + list(c[3:]))
         else:
@@ -727,7 +747,8 @@ def make_spinepartdf(f):
                 new_tuple = tuple([c[0]] + [mappos(c[1])] + list(c[2:]))
         return new_tuple
 
+    spine_part_df.columns = pd.MultiIndex.from_tuples(
+        [fixpos(c) for c in spine_part_df.columns]
+    )
 
-    epartdf.columns = pd.MultiIndex.from_tuples([fixpos(c) for c in epartdf.columns])
-
-    return epartdf
+    return spine_part_df

--- a/pyanalib/pandas_helpers.py
+++ b/pyanalib/pandas_helpers.py
@@ -199,3 +199,28 @@ def add_upper_level_to_df(level_name, df):
     )
     return df
 
+def rename_to_XYZ(df, cols_to_rename):
+    """
+    Rename columns with I0, I1, I2 to x, y, z respectively, but only if they are immediately preceded by 
+    one of the specified column names.
+
+    :param df: Input DataFrame with columns to rename.
+    :type df: pandas.DataFrame
+    :param cols_to_rename: List of column names that should trigger the renaming of
+    I0, I1, I2 to x, y, z when they immediately follow them.
+    :type cols_to_rename: list of str
+    :return: DataFrame with specified columns renamed to x, y, z where applicable.
+    :rtype: pandas.DataFrame
+    """
+
+    coordinates_map = {"I0": "x", "I1": "y", "I2": "z"}
+
+    def rename_col(c):
+        new_col = c
+        for col_level, col_val in enumerate(c):
+            if col_val in cols_to_rename and col_level + 1 < len(c):
+                next_level = col_level + 1
+                new_col = c[:next_level] + (coordinates_map.get(c[next_level], c[next_level]),) + c[next_level + 1:]
+        return new_col
+
+    df.columns = pd.MultiIndex.from_tuples([rename_col(c) for c in df.columns])

--- a/pyanalib/pandas_helpers.py
+++ b/pyanalib/pandas_helpers.py
@@ -182,5 +182,20 @@ def pad_column_name(col, pad_ref): # TODO: merge with the above "pad" function
     extended_name = col + ("",) * ndummies
     return extended_name
 
+def add_upper_level_to_df(level_name, df):
+    """
+    Prepend a new top level to all columns of a DataFrame, handling both string and MultiIndex columns.
 
+    :param level_name: Name of the new top-level column label.
+    :type level_name: str
+    :param df: Input DataFrame.
+    :type df: pandas.DataFrame
+    :return: DataFrame with ``level_name`` prepended to all column levels.
+    :rtype: pandas.DataFrame
+    """
+    df.columns = pd.MultiIndex.from_tuples(
+        [(level_name,) + (col if isinstance(col, tuple) else (col,)) 
+         for col in df.columns]
+    )
+    return df
 


### PR DESCRIPTION
## SPINE Dataframe Makers Update for Gen2 Flat CAF Variables

This PR updates the SPINE dataframe makers to reflect the latest changes in the flat CAF SPINE variables for Gen2, including a full refactorization and improvements in efficiency, modularity, and legibility.

## Changes included

- Refactorization of previous SPINE branches, with addition of all non-string SPINE variables.
- Restructuring of previous SPINE dataframe makers into 6 new specialized makers:
  - Optical flashes SPINE dataframe
  - SPINE interaction variables dataframe (with and without matched MC)
  - SPINE particles variables dataframe (with and without matched MC)
  - Full SPINE dataframe maker built on top of the interaction and particles dataframes

Variable and branch naming now follows the CAF naming convention for general use.