### PR TITLE
Bugfix (`make_all_pandora_df`)

### DIFF
--- a/makedf/makedf.py
+++ b/makedf/makedf.py
@@ -457,7 +457,7 @@ def make_all_pandora_df(f):
     slcdf = multicol_add(slcdf, dmagdf(slcdf.slc.vertex, slcdf.pfp.trk.start).rename(("pfp", "trk", "dist_to_vertex")))
     slcdf = multicol_add(slcdf, dmagdf(slcdf.slc.vertex, slcdf.pfp.shw.start).rename(("pfp", "shw", "dist_to_vertex")))
 
-    return pfpdf
+    return slcdf
 
 def make_pandora_df_calo_update(f, **trkArgs):
     pandoradf = make_pandora_df(f, trkScoreCut=False, trkDistCut=50., cutClearCosmic=True, requireFiducial=False, updatecalo=True, **trkArgs)


### PR DESCRIPTION
## Summary

This PR fixes a bug in `make_all_pandora_df` (`makdef/makedf.py`), where the function was returning an incomplete dataframe.

## Changes included
`make_all_pandora_df` now correctly returns `slcdf`, the dataframe containing all slices and PFPs from the Pandora branches, instead of only PFP variables as before.